### PR TITLE
:sparkles: add ray_init_options field

### DIFF
--- a/dagster_ray/resources.py
+++ b/dagster_ray/resources.py
@@ -29,12 +29,18 @@ class LocalRay(BaseRayResource):
     def host(self) -> str:
         return "127.0.0.1"
 
+    # the address is overwritten by None since ray.init does not behave as expected
+    # when the host is set to localhost or 127.0.0.1
+    @property
+    def ray_address(self) -> None:  # type: ignore
+        return None
+
     @contextlib.contextmanager
     def yield_for_execution(self, context: InitResourceContext) -> Generator[Self, None, None]:
         assert context.log is not None
         assert context.dagster_run is not None
 
-        context.log.debug(f"Ray host: {self.host}")
+        context.log.debug("Connecting to a local Ray cluster...")
 
         self.init_ray(context)
 

--- a/dagster_ray/utils.py
+++ b/dagster_ray/utils.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import dagster as dg
+from dagster._config.field_utils import IntEnvVar
+
+# yes, `python-client` is actually the KubeRay package name
+# https://github.com/ray-project/kuberay/issues/2078
 
 
 def resolve_env_vars_list(env_vars: list[str] | None) -> dict[str, str]:
@@ -16,3 +24,24 @@ def resolve_env_vars_list(env_vars: list[str] | None) -> dict[str, str]:
                     res[env_var] = value
 
     return res
+
+
+def _process_dagster_env_vars(config: Any) -> Any:
+    # If it's already one of the EnvVar types, return its value
+    if isinstance(config, (dg.EnvVar, IntEnvVar)):
+        return config.get_value()
+
+    # If it's exactly {"env": "FOO"}, fetch the value
+    if isinstance(config, Mapping) and len(config) == 1 and "env" in config:
+        return dg.EnvVar(config["env"]).get_value()
+
+    # If it's a dictionary, recurse into its values
+    if isinstance(config, Mapping):
+        return {k: _process_dagster_env_vars(v) for k, v in config.items()}
+
+    # If it's a list/tuple, recurse into each element
+    if isinstance(config, Sequence) and not isinstance(config, str):
+        return [_process_dagster_env_vars(v) for v in config]
+
+    # Otherwise, just return as-is
+    return config

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,61 @@
+import os
+
+import dagster as dg
+
+from dagster_ray import LocalRay, RayResource
+
+
+def test_runtime_env():
+    import ray
+
+    ray.init
+
+    @ray.remote
+    def my_func():
+        assert os.environ["FOO"] == "BAR"
+
+    @dg.asset
+    def my_asset(ray_cluster: RayResource) -> None:
+        ray.get(my_func.remote())
+
+    ray_cluster = LocalRay(ray_init_options={"runtime_env": {"env_vars": {"FOO": "BAR"}}})
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        dg.materialize(
+            assets=[my_asset],
+            instance=instance,
+            resources={"ray_cluster": ray_cluster},
+        )
+
+
+def test_runtime_env_env_var():
+    import ray
+
+    ray.init
+
+    @ray.remote
+    def my_func():
+        assert os.environ["FOO"] == "BAR"
+
+    @dg.asset
+    def my_asset(ray_cluster: RayResource) -> None:
+        ray.get(my_func.remote())
+
+    os.environ["BAR"] = "BAR"
+
+    with dg.DagsterInstance.ephemeral() as instance:
+        dg.materialize(
+            assets=[my_asset],
+            instance=instance,
+            resources={
+                "ray_cluster": LocalRay(ray_init_options={"runtime_env": {"env_vars": {"FOO": dg.EnvVar("BAR")}}})
+            },
+        )
+
+        dg.materialize(
+            assets=[my_asset],
+            instance=instance,
+            resources={
+                "ray_cluster": LocalRay(ray_init_options={"runtime_env": {"env_vars": {"FOO": {"env": "BAR"}}}})
+            },
+        )


### PR DESCRIPTION
This PR adds a `ray_init_options` field to Ray resources. 
It can be used to set options such as `num_cpus`, `runtime_env`, and others. 
See https://docs.ray.io/en/latest/ray-core/api/doc/ray.init.html for more details