### PR TITLE
:sparkles: attach metadata and improve message/log reading

### DIFF
--- a/dagster_ray/_base/utils.py
+++ b/dagster_ray/_base/utils.py
@@ -14,8 +14,13 @@ def get_dagster_tags(context: InitResourceContext | OpExecutionContext | AssetEx
     """
     assert context.dagster_run is not None
 
+    if isinstance(context, InitResourceContext):
+        run_id = cast(str, context.run_id)
+    else:
+        run_id = context.run.run_id
+
     labels = {
-        "dagster.io/run_id": cast(str, context.run_id),
+        "dagster.io/run_id": run_id,
         "dagster.io/deployment": DEFAULT_DEPLOYMENT_NAME,
         # TODO: add more labels
     }

--- a/dagster_ray/kuberay/pipes.py
+++ b/dagster_ray/kuberay/pipes.py
@@ -23,7 +23,12 @@ from dagster_ray._base.utils import get_dagster_tags
 from dagster_ray.kuberay.client import RayJobClient
 from dagster_ray.kuberay.client.rayjob.client import RayJobStatus
 from dagster_ray.kuberay.utils import normalize_k8s_label_values
-from dagster_ray.pipes import PipesRayJobMessageReader, generate_job_id
+from dagster_ray.pipes import (
+    PIPES_LAUNCHED_EXTRAS_RAY_ADDRESS_KEY,
+    PIPES_LAUNCHED_EXTRAS_RAY_JOB_ID_KEY,
+    PipesRayJobMessageReader,
+    generate_job_id,
+)
 
 if TYPE_CHECKING:
     from ray.job_submission import JobSubmissionClient
@@ -100,7 +105,9 @@ class PipesKubeRayJobClient(PipesClient, TreatAsResourceParam):
             extras=extras,
         ) as session:
             ray_job = self._enrich_ray_job(context, session, ray_job)
-            start_response = self._start(context, ray_job)
+            start_response = self._start(context, session, ray_job)
+            start_status = cast(RayJobStatus, start_response["status"])
+            ray_job_id = start_status["jobId"]
 
             name = ray_job["metadata"]["name"]
             namespace = ray_job["metadata"]["namespace"]
@@ -112,10 +119,21 @@ class PipesKubeRayJobClient(PipesClient, TreatAsResourceParam):
             ) as job_submission_client:
                 self._job_submission_client = job_submission_client
 
+                session.report_launched(
+                    {
+                        "extras": {
+                            PIPES_LAUNCHED_EXTRAS_RAY_JOB_ID_KEY: ray_job_id,
+                            PIPES_LAUNCHED_EXTRAS_RAY_ADDRESS_KEY: job_submission_client.get_address(),
+                        }
+                    }
+                )
+
                 try:
-                    self._read_messages(context, start_response)
+                    # self._read_messages(context, start_response)
                     self._wait_for_completion(context, start_response)
-                    return PipesClientCompletedInvocation(session)
+                    return PipesClientCompletedInvocation(
+                        session, metadata={"RayJob": f"{namespace}/{name}", "Ray Job ID": ray_job_id}
+                    )
 
                 except DagsterExecutionInterruptedError:
                     if self.forward_termination:
@@ -160,7 +178,9 @@ class PipesKubeRayJobClient(PipesClient, TreatAsResourceParam):
 
         return ray_job
 
-    def _start(self, context: OpOrAssetExecutionContext, ray_job: dict[str, Any]) -> dict[str, Any]:
+    def _start(
+        self, context: OpOrAssetExecutionContext, session: PipesSession, ray_job: dict[str, Any]
+    ) -> dict[str, Any]:
         name = ray_job["metadata"]["name"]
         namespace = ray_job["metadata"]["namespace"]
 
@@ -184,18 +204,6 @@ class PipesKubeRayJobClient(PipesClient, TreatAsResourceParam):
             namespace=ray_job["metadata"]["namespace"],
             name=ray_job["metadata"]["name"],
         )
-
-    def _read_messages(self, context: OpOrAssetExecutionContext, start_response: dict[str, Any]) -> None:
-        status = cast(RayJobStatus, start_response["status"])
-
-        if isinstance(self._message_reader, PipesRayJobMessageReader):
-            # starts a thread
-            self._message_reader.consume_job_logs(
-                # TODO: investigate why some messages aren't being handled with blocking=False
-                client=self.job_submission_client,
-                job_id=status["jobId"],
-                blocking=True,
-            )
 
     def _wait_for_completion(self, context: OpOrAssetExecutionContext, start_response: dict[str, Any]) -> RayJobStatus:
         context.log.info("[pipes] Waiting for RayJob to complete...")

--- a/dagster_ray/pipes.py
+++ b/dagster_ray/pipes.py
@@ -18,7 +18,7 @@ from dagster._core.pipes.client import (
     PipesContextInjector,
     PipesMessageReader,
 )
-from dagster._core.pipes.context import PipesMessageHandler, PipesSession
+from dagster._core.pipes.context import PipesLaunchedData, PipesMessageHandler, PipesSession
 from dagster._core.pipes.utils import (
     PipesEnvContextInjector,
     _join_thread,
@@ -37,17 +37,60 @@ if TYPE_CHECKING:
 OpOrAssetExecutionContext: TypeAlias = Union[OpExecutionContext, AssetExecutionContext]
 
 
+PIPES_LAUNCHED_EXTRAS_RAY_ADDRESS_KEY = "ray_address"
+PIPES_LAUNCHED_EXTRAS_RAY_JOB_ID_KEY = "ray_job_id"
+
+
 @beta
 class PipesRayJobMessageReader(PipesMessageReader):
-    """
+    f"""
     Dagster Pipes message reader for receiving messages from a Ray job.
     Will extract Dagster events and forward the rest to stdout.
+
+    Waits for PipesSession.report_launched to be called with `{PIPES_LAUNCHED_EXTRAS_RAY_ADDRESS_KEY}` and `{PIPES_LAUNCHED_EXTRAS_RAY_JOB_ID_KEY}` keys
+    populated in `extras` in order to start message reading.
+
+    Args:
+        _job_submission_client_kwargs (Optional[dict[str, Any]]): additional arguments for `ray.job_submission.JobSubmissionClient`. The `address` value is expected to be set via `PipesSession.report_launched`, while other arguments can be set via this parameter.
     """
 
-    def __init__(self):
+    _client: JobSubmissionClient | None
+    _job_id: str | None
+
+    def __init__(self, job_submission_client_kwargs: dict[str, Any] | None = None):
+        self._job_submission_client_kwargs = job_submission_client_kwargs
         self._handler: PipesMessageHandler | None = None
         self._thread: threading.Thread | None = None
         self.session_closed = threading.Event()
+        self._job_id = None
+        self._client = None
+
+    @property
+    def client(self) -> JobSubmissionClient:
+        if self._client is None:
+            raise RuntimeError(
+                "client is only available after it has been set in the Pipes client via PipesSession.report_launched"
+            )
+        else:
+            return self._client
+
+    def on_launched(self, launched_payload: PipesLaunchedData) -> None:
+        from ray.job_submission import JobSubmissionClient
+
+        self._client = JobSubmissionClient(
+            address=launched_payload["extras"][PIPES_LAUNCHED_EXTRAS_RAY_ADDRESS_KEY],
+            **(self._job_submission_client_kwargs or {}),
+        )
+        self._job_id = launched_payload["extras"][PIPES_LAUNCHED_EXTRAS_RAY_JOB_ID_KEY]
+
+    @property
+    def job_id(self) -> str:
+        if self._job_id is None:
+            raise RuntimeError(
+                "job_id is only available after it has been set in the Pipes client via PipesSession.report_launched"
+            )
+        else:
+            return self._job_id
 
     @contextmanager
     def read_messages(self, handler: PipesMessageHandler) -> Iterator[PipesParams]:
@@ -55,6 +98,11 @@ class PipesRayJobMessageReader(PipesMessageReader):
         self._handler = handler
 
         try:
+            self._thread = threading.Thread(
+                target=self.handle_job_logs,
+                daemon=True,
+            )
+            self._thread.start()
             yield {PipesDefaultMessageWriter.STDIO_KEY: PipesDefaultMessageWriter.STDOUT}
         finally:
             self.terminate()
@@ -71,69 +119,58 @@ class PipesRayJobMessageReader(PipesMessageReader):
 
         if self._thread is not None:
             _join_thread(self._thread, "ray job logs tailing")
+            if self._job_id is None:
+                self.handler._context.log.warning(
+                    "[Pipes] PipesRayJobMessageReader._job_id is not set. It's expected to be set via PipesSession.report_launched."
+                )
 
         self._handler = None
 
-    # TODO: call this method as part of self.read_messages
-    def consume_job_logs(self, client: JobSubmissionClient, job_id: str, blocking: bool = False) -> None:
-        if blocking:
-            handle_job_logs(handler=self.handler, client=client, job_id=job_id, session_closed=None)
-        else:
-            self._thread = threading.Thread(
-                target=handle_job_logs,
-                kwargs={
-                    "handler": self.handler,
-                    "client": client,
-                    "job_id": job_id,
-                    "session_closed": self.session_closed,
-                },
-                daemon=True,
-            )
-            self._thread.start()
-
     def no_messages_debug_text(self) -> str:
-        return "Tried to read messages from a Ray job logs, but no messages were received."
+        return f"Tried to read messages from Ray Job logs, but no messages were received. Make sure PipesSession.report_launched has been called with `{PIPES_LAUNCHED_EXTRAS_RAY_JOB_ID_KEY}` set under `extras` field."
 
+    def handle_job_logs(
+        self,
+    ):
+        import asyncio
 
-def handle_job_logs(
-    handler: PipesMessageHandler, client: JobSubmissionClient, job_id: str, session_closed: threading.Event | None
-):
-    import asyncio
+        while self._job_id is None:
+            time.sleep(1.0)
 
-    async_tailer = client.tail_job_logs(job_id=job_id)
+        async_tailer = self.client.tail_job_logs(job_id=self.job_id)
 
-    # Backward compatible sync generator
-    def tail_logs() -> Generator[str, None, None]:
-        while True:
-            try:
+        # Backward compatible sync generator
+        def tail_logs() -> Generator[str, None, None]:
+            while True:
                 try:
-                    loop = asyncio.get_event_loop()
-                except RuntimeError:
-                    loop = asyncio.new_event_loop()
-                    asyncio.set_event_loop(loop)
-                yield loop.run_until_complete(async_tailer.__anext__())  # type: ignore
-            except (StopAsyncIteration, ValueError):
-                break
+                    try:
+                        loop = asyncio.get_event_loop()
+                    except RuntimeError:
+                        loop = asyncio.new_event_loop()
+                        asyncio.set_event_loop(loop)
+                    yield loop.run_until_complete(async_tailer.__anext__())  # type: ignore
+                except (StopAsyncIteration, ValueError):
+                    break
 
-    session_closed_at = None
+        session_closed_at = None
 
-    for chunk in tail_logs():
-        for log_line in chunk.split("\n"):
-            if log_line:
-                extract_message_or_forward_to_stdout(handler, log_line)
+        for chunk in tail_logs():
+            for log_line in chunk.split("\n"):
+                if log_line:
+                    extract_message_or_forward_to_stdout(self.handler, log_line)
 
-        if session_closed is not None and session_closed.is_set():
-            if session_closed_at is None:
-                session_closed_at = time.time()
+            if self.session_closed is not None and self.session_closed.is_set():
+                if session_closed_at is None:
+                    session_closed_at = time.time()
 
-            if time.time() - session_closed_at > 30:  # wait for 30 seconds to flush all logs
-                session_closed.wait()
-                return
+                if time.time() - session_closed_at > 30:  # wait for 30 seconds to flush all logs
+                    self.session_closed.wait()
+                    return
 
-    if session_closed is not None:
-        session_closed.wait()
+        if self.session_closed is not None:
+            self.session_closed.wait()
 
-    return
+        return
 
 
 class SubmitJobParams(TypedDict):
@@ -225,12 +262,12 @@ class PipesRayJobClient(PipesClient, TreatAsResourceParam):
         ) as session:
             enriched_submit_job_params = self._enrich_submit_job_params(context, session, submit_job_params)
 
-            job_id = self._start(context, enriched_submit_job_params)
+            job_id = self._start(context, session, enriched_submit_job_params)
 
             try:
-                self._read_messages(context, job_id)
+                # self._read_messages(context, job_id)
                 self._wait_for_completion(context, job_id)
-                return PipesClientCompletedInvocation(session)
+                return PipesClientCompletedInvocation(session, metadata={"Ray Job ID": job_id})
 
             except DagsterExecutionInterruptedError:
                 if self.forward_termination:
@@ -260,7 +297,9 @@ class PipesRayJobClient(PipesClient, TreatAsResourceParam):
 
         return cast(EnrichedSubmitJobParams, submit_job_params)
 
-    def _start(self, context: OpOrAssetExecutionContext, submit_job_params: EnrichedSubmitJobParams) -> str:
+    def _start(
+        self, context: OpOrAssetExecutionContext, session: PipesSession, submit_job_params: EnrichedSubmitJobParams
+    ) -> str:
         submission_id = submit_job_params["submission_id"]
 
         context.log.info(f"[pipes] Starting Ray job {submission_id}...")
@@ -269,17 +308,16 @@ class PipesRayJobClient(PipesClient, TreatAsResourceParam):
 
         context.log.info(f"[pipes] Ray job {job_id} started.")
 
-        return job_id
+        session.report_launched(
+            {
+                "extras": {
+                    PIPES_LAUNCHED_EXTRAS_RAY_JOB_ID_KEY: job_id,
+                    PIPES_LAUNCHED_EXTRAS_RAY_ADDRESS_KEY: self.client.get_address(),
+                }
+            }
+        )
 
-    def _read_messages(self, context: OpOrAssetExecutionContext, job_id: str) -> None:
-        if isinstance(self._message_reader, PipesRayJobMessageReader):
-            # starts a thread
-            self._message_reader.consume_job_logs(
-                # TODO: investigate why some messages aren't being handled with blocking=False
-                client=self.client,
-                job_id=job_id,
-                blocking=True,
-            )
+        return job_id
 
     def _wait_for_completion(self, context: OpOrAssetExecutionContext, job_id: str) -> JobStatus:
         from ray.job_submission import JobStatus

--- a/dagster_ray/pipes.py
+++ b/dagster_ray/pipes.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 import random
 import string
 import threading
 import time
-from collections.abc import Generator, Iterator
+from collections.abc import AsyncIterator, Generator, Iterator
 from contextlib import contextmanager
+from functools import partial
 from typing import TYPE_CHECKING, Any, TypedDict, Union, cast
 
 import dagster._check as check
@@ -30,6 +33,8 @@ from typing_extensions import NotRequired, TypeAlias
 
 from dagster_ray._base.utils import get_dagster_tags
 
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     from ray.job_submission import JobStatus, JobSubmissionClient
 
@@ -39,6 +44,23 @@ OpOrAssetExecutionContext: TypeAlias = Union[OpExecutionContext, AssetExecutionC
 
 PIPES_LAUNCHED_EXTRAS_RAY_ADDRESS_KEY = "ray_address"
 PIPES_LAUNCHED_EXTRAS_RAY_JOB_ID_KEY = "ray_job_id"
+
+
+def tail_logs(tailer: AsyncIterator[str]) -> Generator[str | None, None, None]:
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    while True:
+        try:
+            yield loop.run_until_complete(tailer.__anext__())  # type: ignore
+        except (StopAsyncIteration, ValueError):
+            break
+        except Exception:
+            logger.exception("Encountered exception during ray job log tailing")
+            yield None
 
 
 @beta
@@ -59,20 +81,31 @@ class PipesRayJobMessageReader(PipesMessageReader):
 
     def __init__(self, job_submission_client_kwargs: dict[str, Any] | None = None):
         self._job_submission_client_kwargs = job_submission_client_kwargs
-        self._handler: PipesMessageHandler | None = None
         self._thread: threading.Thread | None = None
         self.session_closed = threading.Event()
         self._job_id = None
         self._client = None
+        self.thread_ready = threading.Event()
+
+        self.completed = threading.Event()
 
     @property
     def client(self) -> JobSubmissionClient:
         if self._client is None:
             raise RuntimeError(
-                "client is only available after it has been set in the Pipes client via PipesSession.report_launched"
+                "client is only available after it has been seeded in the Pipes client via PipesSession.report_launched"
             )
         else:
             return self._client
+
+    @property
+    def job_id(self) -> str:
+        if self._job_id is None:
+            raise RuntimeError(
+                "job_id is only available after it has been seeded in the Pipes client via PipesSession.report_launched"
+            )
+        else:
+            return self._job_id
 
     def on_launched(self, launched_payload: PipesLaunchedData) -> None:
         from ray.job_submission import JobSubmissionClient
@@ -83,94 +116,79 @@ class PipesRayJobMessageReader(PipesMessageReader):
         )
         self._job_id = launched_payload["extras"][PIPES_LAUNCHED_EXTRAS_RAY_JOB_ID_KEY]
 
-    @property
-    def job_id(self) -> str:
-        if self._job_id is None:
-            raise RuntimeError(
-                "job_id is only available after it has been set in the Pipes client via PipesSession.report_launched"
-            )
-        else:
-            return self._job_id
+        super().on_launched(launched_payload)
+
+    def messages_are_readable(self, params: PipesParams) -> bool:
+        return self._job_id is not None and self._client is not None
 
     @contextmanager
     def read_messages(self, handler: PipesMessageHandler) -> Iterator[PipesParams]:
-        #  This method should start a thread to continuously read messages from some location
-        self._handler = handler
-
         try:
             self._thread = threading.Thread(
-                target=self.handle_job_logs,
+                target=partial(self.handle_job_logs, handler),
                 daemon=True,
             )
             self._thread.start()
             yield {PipesDefaultMessageWriter.STDIO_KEY: PipesDefaultMessageWriter.STDOUT}
         finally:
-            self.terminate()
+            self.terminate(handler)
 
-    @property
-    def handler(self) -> PipesMessageHandler:
-        if self._handler is None:
-            raise Exception("PipesMessageHandler is only available while reading messages in open_pipes_session")
-
-        return self._handler
-
-    def terminate(self) -> None:
+    def terminate(self, handler: PipesMessageHandler) -> None:
         self.session_closed.set()
 
         if self._thread is not None:
             _join_thread(self._thread, "ray job logs tailing")
             if self._job_id is None:
-                self.handler._context.log.warning(
+                handler._context.log.warning(
                     "[Pipes] PipesRayJobMessageReader._job_id is not set. It's expected to be set via PipesSession.report_launched."
                 )
-
-        self._handler = None
 
     def no_messages_debug_text(self) -> str:
         return f"Tried to read messages from Ray Job logs, but no messages were received. Make sure PipesSession.report_launched has been called with `{PIPES_LAUNCHED_EXTRAS_RAY_JOB_ID_KEY}` set under `extras` field."
 
     def handle_job_logs(
         self,
+        handler: PipesMessageHandler,
     ):
-        import asyncio
+        try:
+            while (self._job_id is None or self._client is None) and not self.session_closed.is_set():
+                time.sleep(0.1)
 
-        while self._job_id is None:
-            time.sleep(1.0)
+            self.thread_ready.set()
 
-        async_tailer = self.client.tail_job_logs(job_id=self.job_id)
+            if self.session_closed.is_set():
+                handler._context.log.warning(
+                    "[pipes] PipesSession.report_launched was not called before session was closed."
+                )
+                return
+            else:
+                handler._context.log.debug("[pipes] PipesRayJobMessageReader is ready to begin reading ray job logs")
 
-        # Backward compatible sync generator
-        def tail_logs() -> Generator[str, None, None]:
-            while True:
-                try:
-                    try:
-                        loop = asyncio.get_event_loop()
-                    except RuntimeError:
-                        loop = asyncio.new_event_loop()
-                        asyncio.set_event_loop(loop)
-                    yield loop.run_until_complete(async_tailer.__anext__())  # type: ignore
-                except (StopAsyncIteration, ValueError):
-                    break
+            assert self._job_id is not None and self._client is not None, (
+                "Job ID and client are required for tailing logs. Expected on_launched to set them by this line."
+            )
 
-        session_closed_at = None
+            session_closed_at = None
 
-        for chunk in tail_logs():
-            for log_line in chunk.split("\n"):
-                if log_line:
-                    extract_message_or_forward_to_stdout(self.handler, log_line)
+            tailer = self.client.tail_job_logs(job_id=self.job_id)
 
-            if self.session_closed is not None and self.session_closed.is_set():
-                if session_closed_at is None:
-                    session_closed_at = time.time()
+            for chunk in tail_logs(tailer):
+                if chunk:
+                    for log_line in chunk.split("\n"):
+                        if log_line:
+                            extract_message_or_forward_to_stdout(handler, log_line)
 
-                if time.time() - session_closed_at > 30:  # wait for 30 seconds to flush all logs
-                    self.session_closed.wait()
-                    return
+                if self.session_closed.is_set():
+                    if session_closed_at is None:
+                        session_closed_at = time.time()
 
-        if self.session_closed is not None:
-            self.session_closed.wait()
-
-        return
+                    if time.time() - session_closed_at > 30:  # wait for 30 seconds to flush all logs
+                        self.completed.set()
+                        return
+        except:
+            raise
+        finally:
+            self.completed.set()
 
 
 class SubmitJobParams(TypedDict):

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
           stdenv.cc
           uv
           python
+          minikube
         ];
         LD_LIBRARY_PATH = lib.makeLibraryPath [pkgs.stdenv.cc.cc.lib pkgs.glib pkgs.python39];
         UV_PYTHON = "${python}/bin/python";

--- a/tests/kuberay/conftest.py
+++ b/tests/kuberay/conftest.py
@@ -68,9 +68,6 @@ def dagster_ray_image():
                 image,
                 str(ROOT_DIR),
             ],
-            env={
-                "DOCKER_BUILDKIT": "1",
-            },
             check=True,
         )
     else:


### PR DESCRIPTION
- `PipesRayJobMessageReader` has been reworked. It's now always non-blocking (starts a background thread that does log reading when entering the `.read_messages` context manager). The thread waits for `self._job_id` and `self._client` to be set, which happens via the `on_launched` hook called by the Pipes machinery whenever the `PipesSession.report_launched` is called. Pipes clients must call this method explicitly. `ray_job_id` and `ray_address` must be provided under launched data `extras` key. 
- `PipesRayJobMessageReader` now properly logs exceptions in the log reading thread
- Pipes clients now automatically attach metadata to all asset materializations. This metadata includes `Ray Job ID` and `RayJob` keys. 

I'm hoping to fix https://github.com/danielgafni/dagster-ray/issues/116 as part of this issue. In the worst case the message reader will at least produce more error logs now. 

---

This PR includes a work-around for waiting for the message reader to stop in the Kube RayJob pipes client body if port-forwarding is enabled so that the message reader doesn't fail when port-forwarding exits. [Another PR ](https://github.com/danielgafni/dagster-ray/pull/123) will remove this work-around by introducing a dedicated `PipesKubeRayJobMessageReader`. 