### PR TITLE
Improve KubeRayCluster cleanup

### DIFF
--- a/dagster_ray/kuberay/resources.py
+++ b/dagster_ray/kuberay/resources.py
@@ -170,7 +170,7 @@ class KubeRayCluster(BaseRayResource):
                 self._context = None
 
             yield self
-        except Exception as e:
+        except BaseException as e:
             context.log.critical(f"Couldn't create or connect to RayCluster {self.namespace}/{self.cluster_name}!")
             self._maybe_cleanup_raycluster(context)
             raise e


### PR DESCRIPTION
Thanks for creating this amazing package! It's been super useful for running some of our ray workloads via dagster.

**Summary**:
Ensure that KubeRayCluster resources properly delete running ray clusters in case a dagster job fails with a `BaseException` type.

**Issue**:
I noticed that when a ray cluster has not started yet (e.g. because it is waiting for resources in a k8s cluster) and the dagster run that created it is terminated via UI, the ray cluster is not terminated.

**Steps to reproduce**:
* Start a dagster run that attempts to launch a ray cluster that remains pending (e.g. ask for more than the available resources). This will ensure that the try/except clause in `yield_for_execution` does not complete yet.
* Terminate the dagster run via dagster UI, which will trigger a `DagsterExecutionInterruptedError`, that inherits directly from `BaseException`.

**Proposed Change**:
Catch `BaseException` instead of `Exception` inside of `yield_for_execution`, because some of the dagster error types like  e.g. `DagsterExecutionInterruptedError` inherit directly from `BaseException` and were therefore not caught before this change.

**Verification**:
I tested this in my dagster deployment. It's not clear to me how to write a unit test for it.

**Open questions**:
I saw that `_maybe_cleanup_raycluster` only runs the cleanup if the dagster status is `!= DagsterRunStatus.FAILURE`. Why is that? Shouldn't the cluster be cleaned up in all cases, unless `skip_cleanup=True`?