### PR TITLE
:sparkles: lazy KubeRayCluster

### DIFF
--- a/CHANDELOG.md
+++ b/CHANDELOG.md
@@ -9,3 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [:bomb: breaking] `dagster_ray.kuberay` Configurations have been unified with KubeRay APIs.
+
+### Added
+- `RayResource` resources now have a `skip_setup` parameter that can be used to lazily postpone creation of ray clusters. The user can manually create the ray cluster inside the Dagster op when (if) needed.

--- a/dagster_ray/_base/resources.py
+++ b/dagster_ray/_base/resources.py
@@ -117,11 +117,11 @@ class BaseRayResource(ConfigurableResource, ABC):
         context.log.info("Initialized Ray!")
         return cast("RayBaseContext", self._context)
 
-    def get_dagster_tags(self, context: InitResourceContext) -> dict[str, str]:
+    def get_dagster_tags(self, context: InitResourceContext | OpOrAssetExecutionContext) -> dict[str, str]:
         tags = get_dagster_tags(context)
         return tags
 
-    def _get_step_key(self, context: InitResourceContext) -> str:
+    def _get_step_key(self, context: InitResourceContext | OpOrAssetExecutionContext) -> str:
         # just return a random string
         # since we want a fresh cluster every time
         return str(uuid.uuid4())


### PR DESCRIPTION
Added a `skip_setup`​ parameter to `RayResource`​ resources to allow lazy creation of Ray clusters.

If this parameter is set to `True`​, the user has to call `ray_cluster.create_and_wait`​ manually in the `op/asset`​ body.