### PR TITLE
:sparkles: implement KubeRayInteractiveJob

### DIFF
--- a/CHANDELOG.md
+++ b/CHANDELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [:bomb: breaking] injected `dagster.io/run_id` Kubernetes label has been renamed to `dagster.io/run-id`. Keys starting with `dagster/` have been converted to `dagster.io/`.
 - [:bomb: breaking] `dagster_ray.kuberay` Configurations have been unified with KubeRay APIs.
+- `dagster-ray` now populates Kubernetes labels with more values (including some useful Dagster Cloud values such as `git-sha`)
 
 ### Added
+- `KubeRayInteractiveJob` -- a new resource that utililizes the new `InteractiveMode` for `RayJob`. It can be used to connect to Ray in Client mode -- like `KubeRayCluster` -- but gives access to `RayJob` features, such as automatic cleanup (`ttlSecondsAfterFinished`), retries (`backoffLimit`) and timeouts (`activeDeadlineSeconds`).
 - `RayResource` resources now have a `skip_setup` parameter that can be used to lazily postpone creation of ray clusters. The user can manually create the ray cluster inside the Dagster op when (if) needed.

--- a/dagster_ray/kuberay/__init__.py
+++ b/dagster_ray/kuberay/__init__.py
@@ -1,8 +1,13 @@
-from dagster_ray.kuberay.configs import RayClusterConfig
+from dagster_ray.kuberay.configs import RayClusterConfig, RayClusterSpec, RayJobConfig, RayJobSpec
 from dagster_ray.kuberay.jobs import cleanup_kuberay_clusters, delete_kuberay_clusters
 from dagster_ray.kuberay.ops import cleanup_kuberay_clusters_op, delete_kuberay_clusters_op
 from dagster_ray.kuberay.pipes import PipesKubeRayJobClient
-from dagster_ray.kuberay.resources import KubeRayCluster, RayClusterClientResource
+from dagster_ray.kuberay.resources import (
+    KubeRayCluster,
+    KubeRayInteractiveJob,
+    KubeRayJobClientResource,
+    RayClusterClientResource,
+)
 from dagster_ray.kuberay.schedules import cleanup_kuberay_clusters_daily
 
 __all__ = [
@@ -15,4 +20,9 @@ __all__ = [
     "cleanup_kuberay_clusters_op",
     "delete_kuberay_clusters_op",
     "cleanup_kuberay_clusters_daily",
+    "RayClusterSpec",
+    "RayJobConfig",
+    "RayJobSpec",
+    "KubeRayInteractiveJob",
+    "KubeRayJobClientResource",
 ]

--- a/dagster_ray/kuberay/client/base.py
+++ b/dagster_ray/kuberay/client/base.py
@@ -148,12 +148,12 @@ class BaseKubeRayClient(Generic[T_Status]):
             namespace=namespace,
         )
 
-    def uodate(self, name: str, ray_patch: Any, namespace: str):
+    def update(self, name: str, namespace: str, body: Any):
         return self._api.patch_namespaced_custom_object(
             group=self.group,
             version=self.version,
             plural=self.plural,
             name=name,
-            body=ray_patch,
+            body=body,
             namespace=namespace,
         )

--- a/dagster_ray/kuberay/client/raycluster/client.py
+++ b/dagster_ray/kuberay/client/raycluster/client.py
@@ -114,6 +114,7 @@ class RayClusterClient(BaseKubeRayClient[RayClusterStatus]):
         namespace: str,
         timeout: int,
         image: str | None = None,
+        poll_interval: float = 5.0,
         log_cluster_conditions: bool = False,
     ) -> tuple[str, RayClusterEndpoints]:
         """
@@ -158,6 +159,8 @@ class RayClusterClient(BaseKubeRayClient[RayClusterStatus]):
             if state == "ready" and status.get("head") and status.get("endpoints", {}).get("dashboard"):
                 logger.debug(f"RayCluster {namespace}/{name} is ready!")
                 return status["head"]["serviceIP"], status["endpoints"]
+
+            time.sleep(poll_interval)
         else:
             raise TimeoutError(
                 f"Timed out ({timeout}s) waiting for RayCluster {namespace}/{name} to be ready. Status: {status}"

--- a/dagster_ray/kuberay/resources/__init__.py
+++ b/dagster_ray/kuberay/resources/__init__.py
@@ -1,16 +1,18 @@
+from dagster_ray.kuberay.configs import RayClusterConfig, RayClusterSpec, RayJobConfig, RayJobSpec
 from dagster_ray.kuberay.resources.raycluster import (
     KubeRayCluster,
-    RayClusterClient,
     RayClusterClientResource,
-    RayClusterConfig,
 )
-from dagster_ray.kuberay.resources.rayjob import KubeRayJobClientResource, RayJobClient
+from dagster_ray.kuberay.resources.rayjob import KubeRayInteractiveJob, KubeRayJobClientResource
 
 __all__ = [
     "KubeRayCluster",
     "RayClusterClientResource",
-    "RayClusterClient",
     "RayClusterConfig",
     "KubeRayJobClientResource",
-    "RayJobClient",
+    "RayJobConfig",
+    "RayJobSpec",
+    "RayClusterSpec",
+    "RayClusterConfig",
+    "KubeRayInteractiveJob",
 ]

--- a/dagster_ray/kuberay/resources/base.py
+++ b/dagster_ray/kuberay/resources/base.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import re
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from dagster import Config, InitResourceContext
+from pydantic import Field, PrivateAttr
+from ray._private.worker import BaseContext as RayBaseContext  # noqa
+
+from dagster_ray._base.constants import DEFAULT_DEPLOYMENT_NAME
+from dagster_ray._base.resources import OpOrAssetExecutionContext
+from dagster_ray.kuberay.utils import get_k8s_object_name
+
+if TYPE_CHECKING:
+    pass
+
+
+class BaseKubeRayResourceConfig(Config):
+    image: str | None = Field(
+        default=None,
+        description="Image to inject into the `RayCluster` spec. Defaults to `dagster/image` run tag. Images already provided in the `RayCluster` spec won't be overridden.",
+    )
+    deployment_name: str = Field(
+        default=DEFAULT_DEPLOYMENT_NAME,
+        description="Dagster deployment name. Is used as a prefix for the Kubernetes resource name. Dagster Cloud variables are used to determine the default value.",
+    )
+    timeout: int = Field(default=600, description="Readiness timeout in seconds")
+
+    _cluster_name: str = PrivateAttr()
+    _host: str = PrivateAttr()
+
+    @property
+    @abstractmethod
+    def cluster_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def namespace(self) -> str:
+        raise NotImplementedError
+
+    def _get_step_name(self, context: InitResourceContext | OpOrAssetExecutionContext) -> str:
+        assert isinstance(context.run_id, str)
+        assert context.dagster_run is not None
+
+        # try to make the name as short as possible
+        cluster_name_prefix = f"dg-{self.deployment_name.replace('-', '')[:8]}-{context.run_id[:8]}"
+
+        dagster_user_email = context.dagster_run.tags.get("user")
+        if dagster_user_email is not None:
+            cluster_name_prefix += f"-{dagster_user_email.replace('.', '').replace('-', '').split('@')[0][:6]}"
+
+        step_key = str(uuid4())
+
+        name_key = get_k8s_object_name(
+            context.run_id,
+            step_key,
+        )
+
+        step_name = f"{cluster_name_prefix}-{name_key}".lower()
+        step_name = re.sub(r"[^-0-9a-z]", "-", step_name)
+
+        return step_name

--- a/dagster_ray/kuberay/resources/rayjob.py
+++ b/dagster_ray/kuberay/resources/rayjob.py
@@ -1,55 +1,182 @@
-from __future__ import annotations
-
 import contextlib
 from collections.abc import Generator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
+import dagster as dg
 from dagster import ConfigurableResource, InitResourceContext
 from dagster._annotations import beta
-from pydantic import PrivateAttr
+from pydantic import Field, PrivateAttr
+from typing_extensions import Self
 
+from dagster_ray._base.resources import BaseRayResource, OpOrAssetExecutionContext
 from dagster_ray.kuberay.client import RayJobClient
 from dagster_ray.kuberay.client.base import load_kubeconfig
+from dagster_ray.kuberay.configs import RayJobConfig, RayJobSpec
+from dagster_ray.kuberay.resources.base import BaseKubeRayResourceConfig
+from dagster_ray.kuberay.utils import normalize_k8s_label_values
+from dagster_ray.utils import get_current_job_id
 
 if TYPE_CHECKING:
-    import kubernetes
+    from ray._private.worker import BaseContext as RayBaseContext  # noqa
+
+if TYPE_CHECKING:
+    pass
 
 
 @beta
 class KubeRayJobClientResource(ConfigurableResource[RayJobClient]):
-    kube_context: str | None = None
-    kubeconfig_file: str | None = None
-
-    _rayjob_client: RayJobClient = PrivateAttr()
-    _k8s_api: kubernetes.client.CustomObjectsApi = PrivateAttr()
-    _k8s_core_api: kubernetes.client.CoreV1Api = PrivateAttr()
-
-    @property
-    def client(self) -> RayJobClient:
-        if self._rayjob_client is None:
-            raise ValueError(f"{self.__class__.__name__} not initialized")
-        return self._raycluster_client
-
-    @property
-    def k8s(self) -> kubernetes.client.CustomObjectsApi:
-        if self._k8s_api is None:
-            raise ValueError(f"{self.__class__.__name__} not initialized")
-        return self._k8s_api
-
-    @property
-    def k8s_core(self) -> kubernetes.client.CoreV1Api:
-        if self._k8s_core_api is None:
-            raise ValueError(f"{self.__class__.__name__} not initialized")
-        return self._k8s_core_api
+    kube_context: "str | None" = None
+    kubeconfig_file: "str | None" = None
 
     @contextlib.contextmanager
     def yield_for_execution(self, context: InitResourceContext) -> Generator[RayJobClient, None, None]:
-        import kubernetes
-
         load_kubeconfig(context=self.kube_context, config_file=self.kubeconfig_file)
 
-        self._rayjob_client = RayJobClient(context=self.kube_context, config_file=self.kubeconfig_file)
-        self._k8s_api = kubernetes.client.CustomObjectsApi()
-        self._k8s_core_api = kubernetes.client.CoreV1Api()
+        yield RayJobClient(context=self.kube_context, config_file=self.kubeconfig_file)
 
-        yield self.client
+
+class InteractiveRayJobSpec(RayJobSpec):
+    submission_mode: Literal["InteractiveMode"] = "InteractiveMode"  # pyright: ignore[reportIncompatibleVariableOverride]
+
+
+class InteractiveRayJobConfig(RayJobConfig):
+    spec: InteractiveRayJobSpec = Field(default_factory=InteractiveRayJobSpec)  # pyright: ignore[reportIncompatibleVariableOverride]
+
+
+@beta
+class KubeRayInteractiveJob(BaseKubeRayResourceConfig, BaseRayResource):
+    """
+    Provides a `RayJob` for the current step selection
+    The cluster is automatically deleted after steps execution
+    """
+
+    ray_job: InteractiveRayJobConfig = Field(
+        default_factory=InteractiveRayJobConfig, description="Configuration for the Kubernetes `RayJob` CR"
+    )
+    client: dg.ResourceDependency[RayJobClient] = Field(
+        # default_factory=KubeRayJobClientResource,
+        description="Kubernetes `RayJob` client"
+    )
+
+    log_cluster_conditions: bool = Field(
+        default=True,
+        description="Whether to log `RayCluster` conditions while waiting for the RayCluster to become ready. For more information, see https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/observability.html#raycluster-status-conditions.",
+    )
+    skip_init: bool = Field(default=False, description="Do not run `ray.init` automatically")
+
+    _job_name: str = PrivateAttr()
+    _cluster_name: str = PrivateAttr()
+    _host: str = PrivateAttr()
+
+    @property
+    def host(self) -> str:
+        if not hasattr(self, "_host"):
+            raise ValueError(f"{self.__class__.__name__} not initialized")
+        return self._host
+
+    @property
+    def job_name(self) -> str:
+        if not hasattr(self, "_job_name"):
+            raise ValueError(f"{self.__class__.__name__} not initialized")
+        elif (name := self.ray_job.metadata.get("name")) is not None:
+            return name
+        else:
+            return self._job_name
+
+    @property
+    def cluster_name(self) -> str:
+        if not hasattr(self, "_cluster_name"):
+            raise ValueError(f"{self.__class__.__name__} not initialized")
+        else:
+            return self._cluster_name
+
+    @property
+    def namespace(self) -> str:
+        return self.ray_job.namespace
+
+    def get_dagster_tags(self, context: "InitResourceContext | OpOrAssetExecutionContext") -> dict[str, str]:
+        tags = super().get_dagster_tags(context=context)
+        tags.update({"dagster.io/deployment": self.deployment_name})
+        return tags
+
+    @contextlib.contextmanager
+    def yield_for_execution(self, context: InitResourceContext) -> Generator[Self, None, None]:
+        assert context.log is not None
+        assert context.dagster_run is not None
+
+        if not self.skip_setup:
+            self.create_and_wait(context)
+
+        yield self
+
+        if self._context is not None:
+            self._context.disconnect()
+
+    def create_and_wait(self, context: "InitResourceContext | OpOrAssetExecutionContext"):
+        assert context.log is not None
+        assert context.dagster_run is not None
+
+        self._job_name = self.ray_job.metadata.get("name") or self._get_step_name(context)
+
+        try:
+            k8s_manifest = self.ray_job.to_k8s(
+                context,
+                image=(self.image or context.dagster_run.tags["dagster/image"]),
+                labels=normalize_k8s_label_values(self.get_dagster_tags(context)),
+            )
+
+            k8s_manifest["metadata"]["name"] = self.job_name
+
+            if not self.client.get(
+                name=self.job_name,
+                namespace=self.namespace,
+            ):
+                resource = self.client.create(body=k8s_manifest, namespace=self.namespace)
+
+                if not resource:
+                    raise RuntimeError(f"Couldn't create RayJob {self.namespace}/{self.cluster_name}")
+
+            context.log.info(
+                f"Created RayJob {self.namespace}/{self.job_name}. Waiting for it to become ready (timeout={self.timeout:.0f}s)..."
+            )
+
+            self.client.wait_until_ready(
+                name=self.job_name, namespace=self.namespace, log_cluster_conditions=self.log_cluster_conditions
+            )
+            self._cluster_name = self.client.get_ray_cluster_name(self.job_name, self.namespace)
+            self._host = self.client.ray_cluster_client.get_status(name=self.cluster_name, namespace=self.namespace)[  # pyright: ignore
+                "head"
+            ]["serviceIP"]
+
+            msg = f"RayJob {self.namespace}/{self.job_name} has created a RayCluster {self.namespace}/{self.cluster_name}! Connection command:\n"
+            msg += f"kubectl -n {self.namespace} port-forward svc/{self.cluster_name}-head-svc 8265:8265 6379:6379 10001:10001"
+
+            context.log.info(msg)
+
+            if not self.skip_init:
+                self.init_ray(context)
+            else:
+                self._context = None
+
+        except BaseException as e:
+            context.log.critical(
+                f"Couldn't create RayJob {self.namespace}/{self.job_name} or connect to RayCluster {self.namespace}/{self.cluster_name}!"
+            )
+            raise e
+
+    def init_ray(self, context: "OpOrAssetExecutionContext | InitResourceContext") -> "RayBaseContext":
+        """Connect to Ray and place a `ray.io/job-submission-id` annotation on the `RayJob` to bind the client session to the `RayJob` CR. Requires KubeRay 1.3.0.
+
+        This procedure is described in https://github.com/ray-project/kuberay/pull/2364
+        """
+        ray_context = super().init_ray(context)
+
+        # now get the job id and annotate it
+        job_id = get_current_job_id()
+        self.client.update(
+            name=self.job_name,
+            namespace=self.namespace,
+            body={"metadata": {"annotations": {"ray.io/job-submission-id": job_id}}},
+        )
+
+        return ray_context

--- a/dagster_ray/utils.py
+++ b/dagster_ray/utils.py
@@ -45,3 +45,9 @@ def _process_dagster_env_vars(config: Any) -> Any:
 
     # Otherwise, just return as-is
     return config
+
+
+def get_current_job_id() -> str:
+    import ray
+
+    return ray.get_runtime_context().get_job_id()

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,7 @@
           uv
           python
           minikube
+          kubectl
         ];
         LD_LIBRARY_PATH = lib.makeLibraryPath [pkgs.stdenv.cc.cc.lib pkgs.glib pkgs.python39];
         UV_PYTHON = "${python}/bin/python";

--- a/tests/kuberay/conftest.py
+++ b/tests/kuberay/conftest.py
@@ -86,7 +86,12 @@ KUBERAY_VERSIONS = os.getenv("PYTEST_KUBERAY_VERSIONS", "1.2.2").split(",")
 
 
 @pytest_cases.fixture(scope="session")  # type: ignore
-@pytest.mark.parametrize("kuberay_version", KUBERAY_VERSIONS)
+@pytest.mark.parametrize("kuberay_version_param", KUBERAY_VERSIONS)
+def kuberay_version(kuberay_version_param: str):
+    return kuberay_version_param
+
+
+@pytest.fixture(scope="session")  # type: ignore
 def k8s_with_kuberay(
     request, kuberay_helm_repo, dagster_ray_image: str, kuberay_version: str
 ) -> Iterator[AClusterManager]:

--- a/tests/kuberay/test_interactive_rayjob.py
+++ b/tests/kuberay/test_interactive_rayjob.py
@@ -1,0 +1,99 @@
+import socket
+from typing import Any, cast
+
+import pytest
+import ray  # noqa: TID253
+from dagster import AssetExecutionContext, asset, materialize_to_memory
+from packaging.version import Version
+from pytest_kubernetes.providers import AClusterManager
+
+from dagster_ray import RayResource
+from dagster_ray.kuberay import (
+    KubeRayCluster,
+    KubeRayInteractiveJob,
+)
+from dagster_ray.kuberay.client.rayjob.client import RayJobClient
+from dagster_ray.kuberay.configs import RayClusterSpec
+from dagster_ray.kuberay.resources.rayjob import InteractiveRayJobConfig, InteractiveRayJobSpec
+from tests.kuberay.utils import NAMESPACE, get_random_free_port
+
+MIN_KUBERAY_VERSION = "1.3.0"
+
+
+@pytest.fixture(scope="session")
+def interative_rayjob_resource(
+    k8s_with_kuberay: AClusterManager,
+    dagster_ray_image: str,
+    head_group_spec: dict[str, Any],
+    worker_group_specs: list[dict[str, Any]],
+    kuberay_version: str,
+) -> KubeRayInteractiveJob:
+    if Version(kuberay_version) < Version(MIN_KUBERAY_VERSION):
+        pytest.skip(f"KubeRay {MIN_KUBERAY_VERSION} is required to use interactive mode with RayJob")
+
+    return KubeRayInteractiveJob(
+        image=dagster_ray_image,
+        client=RayJobClient(config_file=str(k8s_with_kuberay.kubeconfig)),
+        ray_job=InteractiveRayJobConfig(
+            metadata={"namespace": NAMESPACE},
+            spec=InteractiveRayJobSpec(
+                ray_cluster_spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
+            ),
+        ),
+        redis_port=get_random_free_port(),
+        skip_init=True,
+    )
+
+
+@ray.remote
+def get_hostname():
+    return socket.gethostname()
+
+
+def ensure_rayjob_correctness(
+    rayjob: KubeRayInteractiveJob,
+    k8s_with_kuberay: AClusterManager,
+    context: AssetExecutionContext,
+):
+    with k8s_with_kuberay.port_forwarding(
+        target=f"svc/{rayjob.cluster_name}-head-svc",
+        source_port=cast(int, rayjob.redis_port),
+        target_port=10001,
+        namespace=rayjob.namespace,
+    ):
+        # now we can access the head node
+        # hack the _host attribute to point to the port-forwarded address
+        rayjob._host = "127.0.0.1"
+        rayjob.init_ray(context)  # normally this would happen automatically during resource setup
+        assert rayjob.context is not None
+
+        # make sure a @remote function runs inside the cluster
+        # not in localhost
+        assert rayjob.cluster_name in ray.get(get_hostname.remote())
+
+        rayjob_description = rayjob.client.get(rayjob.job_name, namespace=rayjob.namespace)
+        assert rayjob_description["metadata"]["labels"]["dagster.io/run-id"] == context.run_id
+
+
+def test_interactive_rayjob(
+    interative_rayjob_resource: KubeRayCluster,
+    k8s_with_kuberay: AClusterManager,
+):
+    @asset
+    # testing RayResource type annotation too!
+    def my_asset(context: AssetExecutionContext, interactive_rayjob: RayResource) -> None:
+        # port-forward to the head node
+        # because it's not possible to access it otherwise
+
+        assert isinstance(interactive_rayjob, KubeRayInteractiveJob)
+
+        ensure_rayjob_correctness(
+            interactive_rayjob,
+            k8s_with_kuberay,
+            context,
+        )
+
+    materialize_to_memory(
+        [my_asset],
+        resources={"interactive_rayjob": interative_rayjob_resource},
+    )

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -67,8 +67,6 @@ def test_debug_mode():
 def test_runtime_env_env_var(ray_init_options: dict[str, Any]):
     import ray
 
-    ray.init
-
     @ray.remote
     def my_func():
         assert os.environ["FOO"] == "BAR"


### PR DESCRIPTION
The `KubeRayInteractiveJob` utilizes `InteractiveMode` for `RayJob`.
It allows creating up a suspended `RayJob`, submitting a Ray job (via submission API), and they pointing the `RayJob` at the submitted Ray job via `ray.io/job-submission-id` annotation. The normal `RayJob` lifecycle can continue after that.

This is useful because we can benefit from `RayJob` features while staying in client mode without having to call an external script.