### PR TITLE
:bug: fix Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "schedule:monthly"
   ],
-  "schedule": ["schedule:monthly"],
   "labels": ["dependencies"],
   "reviewers": ["danielgafni"],
   "packageRules": [


### PR DESCRIPTION
Fixes #187. The schedule:monthly preset should be in the extends array, not as a standalone schedule property.