### PR TITLE
:wrench: change k8s labels: dagster.io/ -> dagster

### DIFF
--- a/CHANDELOG.md
+++ b/CHANDELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- [:bomb: breaking] injected `dagster.io/run_id` Kubernetes label has been renamed to `dagster.io/run-id`. Keys starting with `dagster/` have been converted to `dagster.io/`.
+- [:bomb: breaking] injected `dagster.io/run_id` Kubernetes label has been renamed to `dagster/run-id`. Keys starting with `dagster.io/` have been converted to `dagster/` to match how `dagster-k8s` does it.
 - [:bomb: breaking] `dagster_ray.kuberay` Configurations have been unified with KubeRay APIs.
 - `dagster-ray` now populates Kubernetes labels with more values (including some useful Dagster Cloud values such as `git-sha`)
 

--- a/dagster_ray/_base/utils.py
+++ b/dagster_ray/_base/utils.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 from dagster import AssetExecutionContext, InitResourceContext, OpExecutionContext
 
 from dagster_ray._base.constants import DEFAULT_DEPLOYMENT_NAME
@@ -16,7 +14,7 @@ def get_dagster_tags(
     assert context.dagster_run is not None
 
     labels: dict[str, str] = {
-        "dagster.io/deployment": DEFAULT_DEPLOYMENT_NAME,  # TODO: this should come from extra_tags,
+        "dagster/deployment": DEFAULT_DEPLOYMENT_NAME,  # TODO: this should come from extra_tags,
         **(extra_tags or {}),
     }
 
@@ -29,19 +27,10 @@ def get_dagster_tags(
             if resource_def is context.resource_def:
                 # inject the resource key used for this KubeRay resource
                 # this enables e.g reusing the same `RayCluster` across Dagster steps that require it without recreating the cluster
-                labels["dagster.io/resource_key"] = resource_key
+                labels["dagster/resource_key"] = resource_key
     else:
         labels.update(
             **context.run.dagster_execution_info,
         )
-
-    if context.dagster_run.tags.get("user"):
-        labels["dagster.io/user"] = context.dagster_run.tags["user"]
-
-    if os.getenv("DAGSTER_CLOUD_GIT_BRANCH"):
-        labels["dagster.io/git-branch"] = os.environ["DAGSTER_CLOUD_GIT_BRANCH"]
-
-    if os.getenv("DAGSTER_CLOUD_GIT_SHA"):
-        labels["dagster.io/git-sha"] = os.environ["DAGSTER_CLOUD_GIT_SHA"]
 
     return labels

--- a/dagster_ray/kuberay/ops.py
+++ b/dagster_ray/kuberay/ops.py
@@ -30,7 +30,7 @@ def delete_kuberay_clusters_op(
 class CleanupKuberayClustersConfig(Config):
     namespace: str = "kuberay"
     label_selector: str = Field(
-        default=f"dagster.io/deployment={DEFAULT_DEPLOYMENT_NAME}", description="Label selector to filter RayClusters"
+        default=f"dagster/deployment={DEFAULT_DEPLOYMENT_NAME}", description="Label selector to filter RayClusters"
     )
 
 
@@ -63,7 +63,7 @@ def cleanup_kuberay_clusters_op(
     old_cluster_names = [
         cluster["metadata"]["name"]
         for cluster in clusters
-        if not any(run.run_id == cluster["metadata"]["labels"]["dagster.io/run-id"] for run in current_runs)
+        if not any(run.run_id == cluster["metadata"]["labels"]["dagster/run-id"] for run in current_runs)
     ]
 
     for cluster_name in old_cluster_names:

--- a/dagster_ray/kuberay/resources/raycluster.py
+++ b/dagster_ray/kuberay/resources/raycluster.py
@@ -112,7 +112,7 @@ class KubeRayCluster(BaseKubeRayResourceConfig, BaseRayResource):
 
     def get_dagster_tags(self, context: InitResourceContext | OpOrAssetExecutionContext) -> dict[str, str]:
         tags = super().get_dagster_tags(context=context)
-        tags.update({"dagster.io/deployment": self.deployment_name})
+        tags.update({"dagster/deployment": self.deployment_name})
         return tags
 
     @contextlib.contextmanager

--- a/dagster_ray/kuberay/resources/rayjob.py
+++ b/dagster_ray/kuberay/resources/rayjob.py
@@ -96,7 +96,7 @@ class KubeRayInteractiveJob(BaseKubeRayResourceConfig, BaseRayResource):
 
     def get_dagster_tags(self, context: "InitResourceContext | OpOrAssetExecutionContext") -> dict[str, str]:
         tags = super().get_dagster_tags(context=context)
-        tags.update({"dagster.io/deployment": self.deployment_name})
+        tags.update({"dagster/deployment": self.deployment_name})
         return tags
 
     @contextlib.contextmanager

--- a/dagster_ray/kuberay/utils.py
+++ b/dagster_ray/kuberay/utils.py
@@ -46,11 +46,11 @@ def normalize_k8s_label_values(labels: dict[str, str]) -> dict[str, str]:
         # Truncate to 63 characters
         normalized[key] = value[:63]
 
-    # replace keys starting with `dagster/` with `dagster.io/`
+    # replace keys starting with `dagster.io/` with `dagster/`
     normalized_with_fixed_dagster_keys = {}
     for key, value in normalized.items():
-        if key.startswith("dagster/"):
-            normalized_with_fixed_dagster_keys[f"dagster.io/{key[8:]}"] = value
+        if key.startswith("dagster.io/"):
+            normalized_with_fixed_dagster_keys[f"dagster/{key[11:]}"] = value
         else:
             normalized_with_fixed_dagster_keys[key] = value
     return normalized_with_fixed_dagster_keys

--- a/tests/kuberay/test_interactive_rayjob.py
+++ b/tests/kuberay/test_interactive_rayjob.py
@@ -72,7 +72,7 @@ def ensure_rayjob_correctness(
         assert rayjob.cluster_name in ray.get(get_hostname.remote())
 
         rayjob_description = rayjob.client.get(rayjob.job_name, namespace=rayjob.namespace)
-        assert rayjob_description["metadata"]["labels"]["dagster.io/run-id"] == context.run_id
+        assert rayjob_description["metadata"]["labels"]["dagster/run-id"] == context.run_id
 
 
 def test_interactive_rayjob(

--- a/tests/kuberay/test_raycluster.py
+++ b/tests/kuberay/test_raycluster.py
@@ -115,7 +115,7 @@ def ensure_kuberay_cluster_correctness(
         ray_cluster_description = ray_cluster.client.client.get(
             ray_cluster.cluster_name, namespace=ray_cluster.namespace
         )
-        assert ray_cluster_description["metadata"]["labels"]["dagster.io/run-id"] == context.run_id
+        assert ray_cluster_description["metadata"]["labels"]["dagster/run-id"] == context.run_id
 
 
 def test_kuberay_cluster_resource(
@@ -148,7 +148,7 @@ def test_kuberay_cluster_resource(
     assert (
         len(
             kuberay_client.list(
-                namespace=ray_cluster_resource.namespace, label_selector=f"dagster.io/run-id={result.run_id}"
+                namespace=ray_cluster_resource.namespace, label_selector=f"dagster/run-id={result.run_id}"
             )["items"]
         )
         == 0
@@ -197,7 +197,7 @@ def test_kuberay_cleanup_job(
         len(
             kuberay_client.list(
                 namespace=ray_cluster_resource_skip_cleanup.namespace,
-                label_selector=f"dagster.io/run-id={result.run_id}",
+                label_selector=f"dagster/run-id={result.run_id}",
             )["items"]
         )
         > 0
@@ -217,7 +217,7 @@ def test_kuberay_cleanup_job(
     )
 
     assert not kuberay_client.list(
-        namespace=ray_cluster_resource_skip_cleanup.namespace, label_selector=f"dagster.io/run-id={result.run_id}"
+        namespace=ray_cluster_resource_skip_cleanup.namespace, label_selector=f"dagster/run-id={result.run_id}"
     )["items"]
 
 

--- a/tests/kuberay/test_utils.py
+++ b/tests/kuberay/test_utils.py
@@ -17,4 +17,4 @@ def test_normalize_k8s_label_values(snapshot):
 
 
 def test_normalize_k8s_label_values_important_labels():
-    assert normalize_k8s_label_values({"dagster/run-id": "12345"}) == {"dagster.io/run-id": "12345"}
+    assert normalize_k8s_label_values({"dagster/run-id": "12345"}) == {"dagster/run-id": "12345"}


### PR DESCRIPTION
I decided to match Dagster’s Kubernetes labels (even tho Dagster doesn’t follow the standard convention).