### PR TITLE
:recycle: refactor skip_init and skip_setup into `lifecycle.create|wait|connect`

### DIFF
--- a/CHANDELOG.md
+++ b/CHANDELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- [:bomb: breaking] `RayResource`: top-level `skip_init` and `skip_setup` configuration parameters have been removed. `Lifecycle` is the new way of configuring steps performed during resource initialization.
 - [:bomb: breaking] injected `dagster.io/run_id` Kubernetes label has been renamed to `dagster/run-id`. Keys starting with `dagster.io/` have been converted to `dagster/` to match how `dagster-k8s` does it.
 - [:bomb: breaking] `dagster_ray.kuberay` Configurations have been unified with KubeRay APIs.
 - `dagster-ray` now populates Kubernetes labels with more values (including some useful Dagster Cloud values such as `git-sha`)
 
 ### Added
 - `KubeRayInteractiveJob` -- a new resource that utililizes the new `InteractiveMode` for `RayJob`. It can be used to connect to Ray in Client mode -- like `KubeRayCluster` -- but gives access to `RayJob` features, such as automatic cleanup (`ttlSecondsAfterFinished`), retries (`backoffLimit`) and timeouts (`activeDeadlineSeconds`).
-- `RayResource` resources now have a `skip_setup` parameter that can be used to lazily postpone creation of ray clusters. The user can manually create the ray cluster inside the Dagster op when (if) needed.
+- `RayResource` setup lifecycle has been overhauled: resources now has an `actions` parameter with 3 configuration options: `create`, `wait` and `connect`. The user can disable them and run `.create()`, `.wait()` and `.connect()` manually if needed.

--- a/dagster_ray/__init__.py
+++ b/dagster_ray/__init__.py
@@ -1,4 +1,4 @@
-from dagster_ray._base.resources import BaseRayResource
+from dagster_ray._base.resources import BaseRayResource, Lifecycle
 from dagster_ray.executor import ray_executor
 from dagster_ray.io_manager import RayIOManager
 from dagster_ray.pipes import PipesRayJobClient, PipesRayJobMessageReader
@@ -9,6 +9,7 @@ RayResource = BaseRayResource
 
 
 __all__ = [
+    "Lifecycle",
     "RayResource",
     "RayRunLauncher",
     "RayIOManager",

--- a/dagster_ray/resources.py
+++ b/dagster_ray/resources.py
@@ -50,7 +50,7 @@ class LocalRay(BaseRayResource):
 
         context.log.debug("Connecting to a local Ray cluster...")
 
-        self.init_ray(context)
+        self.connect(context)
 
         yield self
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ banned-module-level-imports = ["ray", "kubernetes", "torch"]
 
 [tool.pyright]
 pythonVersion = "3.9"
+typeCheckingMode = "standard"
 failOnWarnings = false
 reportPropertyTypeMismatch = true
 reportImportCycles = true
@@ -130,6 +131,18 @@ reportUntypedClassDecorator = true
 reportAny = false
 reportExplicitAny = false
 reportUnusedCallResult = false
+reportAttributeAccessIssue = "error"
+reportGeneralTypeIssues = "error"
+reportUnknownMemberType = "none"
+reportUnknownVariableType = "none"
+reportUnknownArgumentType = "none"
+reportUnknownParameterType = "none"
+reportUnknownLambdaType = "none"
+reportMissingTypeStubs = false
+reportIncompatibleMethodOverride = true
+reportIncompatibleVariableOverride = true
+reportOverlappingOverload = true
+# reportPrivateUsage = "warning"
 
 include = [
     "dagster_ray",

--- a/tests/pyrightconfig.json
+++ b/tests/pyrightconfig.json
@@ -1,3 +1,0 @@
-{
-  "reportPrivateUsage": "false"
-}


### PR DESCRIPTION
This PR removes `skip_init` and `skip_setup` and introduces a new parameter instead: `lifecycle`. 

`lifecycle` takes a `Lifecycle` object that holds the following parameters: `create`, `wait`, `connect`. 

They are set to `True` by default. The user can set them to `False` and call `RayResource.create|wait|connect` methods manually. 