### PR TITLE
:recycle: refactor raycluster and rayjob clients resources

### DIFF
--- a/dagster_ray/kuberay/__init__.py
+++ b/dagster_ray/kuberay/__init__.py
@@ -4,16 +4,16 @@ from dagster_ray.kuberay.ops import cleanup_kuberay_clusters_op, delete_kuberay_
 from dagster_ray.kuberay.pipes import PipesKubeRayJobClient
 from dagster_ray.kuberay.resources import (
     KubeRayCluster,
+    KubeRayClusterClientResource,
     KubeRayInteractiveJob,
     KubeRayJobClientResource,
-    RayClusterClientResource,
 )
 from dagster_ray.kuberay.schedules import cleanup_kuberay_clusters_daily
 
 __all__ = [
     "KubeRayCluster",
     "RayClusterConfig",
-    "RayClusterClientResource",
+    "KubeRayClusterClientResource",
     "PipesKubeRayJobClient",
     "cleanup_kuberay_clusters",
     "delete_kuberay_clusters",

--- a/dagster_ray/kuberay/client/raycluster/client.py
+++ b/dagster_ray/kuberay/client/raycluster/client.py
@@ -97,7 +97,7 @@ class RayClusterStatus(TypedDict):
 class RayClusterClient(BaseKubeRayClient[RayClusterStatus]):
     def __init__(
         self,
-        config_file: str | None = None,
+        kubeconfig_file: str | None = None,
         context: str | None = None,
         api_client: ApiClient | None = None,
     ) -> None:
@@ -105,7 +105,7 @@ class RayClusterClient(BaseKubeRayClient[RayClusterStatus]):
 
         # these are only used because of kubectl port-forward CLI command
         # TODO: remove kubectl usage and remove these attributes
-        self.config_file = config_file
+        self.config_file = kubeconfig_file
         self.context = context
 
     def wait_until_ready(

--- a/dagster_ray/kuberay/client/rayjob/client.py
+++ b/dagster_ray/kuberay/client/rayjob/client.py
@@ -38,14 +38,14 @@ class RayJobStatus(TypedDict):
 class RayJobClient(BaseKubeRayClient[RayJobStatus]):
     def __init__(
         self,
-        config_file: str | None = None,
+        kubeconfig_file: str | None = None,
         context: str | None = None,
         api_client: ApiClient | None = None,
     ) -> None:
         # this call must happen BEFORE creating K8s apis
-        load_kubeconfig(config_file=config_file, context=context)
+        load_kubeconfig(config_file=kubeconfig_file, context=context)
 
-        self.config_file = config_file
+        self.config_file = kubeconfig_file
         self.context = context
 
         super().__init__(group=GROUP, version=VERSION, kind=KIND, plural=PLURAL, api_client=api_client)
@@ -58,7 +58,7 @@ class RayJobClient(BaseKubeRayClient[RayJobStatus]):
 
     @property
     def ray_cluster_client(self) -> RayClusterClient:
-        return RayClusterClient(config_file=self.config_file, context=self.context)
+        return RayClusterClient(kubeconfig_file=self.config_file, context=self.context)
 
     def wait_until_ready(
         self,

--- a/dagster_ray/kuberay/ops.py
+++ b/dagster_ray/kuberay/ops.py
@@ -2,7 +2,7 @@ from dagster import Config, DagsterRunStatus, OpExecutionContext, RunsFilter, op
 from pydantic import Field
 
 from dagster_ray._base.constants import DEFAULT_DEPLOYMENT_NAME
-from dagster_ray.kuberay.resources import RayClusterClientResource
+from dagster_ray.kuberay.resources import KubeRayClusterClientResource
 
 
 class DeleteKubeRayClustersConfig(Config):
@@ -14,7 +14,7 @@ class DeleteKubeRayClustersConfig(Config):
 def delete_kuberay_clusters_op(
     context: OpExecutionContext,
     config: DeleteKubeRayClustersConfig,
-    kuberay_client: RayClusterClientResource,
+    kuberay_client: KubeRayClusterClientResource,
 ) -> None:
     for cluster_name in config.cluster_names:
         try:
@@ -41,7 +41,7 @@ class CleanupKuberayClustersConfig(Config):
 def cleanup_kuberay_clusters_op(
     context: OpExecutionContext,
     config: CleanupKuberayClustersConfig,
-    kuberay_client: RayClusterClientResource,
+    kuberay_client: KubeRayClusterClientResource,
 ) -> None:
     current_runs = context.instance.get_runs(
         filters=RunsFilter(

--- a/dagster_ray/kuberay/resources/__init__.py
+++ b/dagster_ray/kuberay/resources/__init__.py
@@ -1,13 +1,13 @@
 from dagster_ray.kuberay.configs import RayClusterConfig, RayClusterSpec, RayJobConfig, RayJobSpec
 from dagster_ray.kuberay.resources.raycluster import (
     KubeRayCluster,
-    RayClusterClientResource,
+    KubeRayClusterClientResource,
 )
 from dagster_ray.kuberay.resources.rayjob import KubeRayInteractiveJob, KubeRayJobClientResource
 
 __all__ = [
     "KubeRayCluster",
-    "RayClusterClientResource",
+    "KubeRayClusterClientResource",
     "RayClusterConfig",
     "KubeRayJobClientResource",
     "RayJobConfig",

--- a/dagster_ray/kuberay/resources/raycluster.py
+++ b/dagster_ray/kuberay/resources/raycluster.py
@@ -51,7 +51,7 @@ class KubeRayCluster(BaseKubeRayResourceConfig, BaseRayResource):
     ray_cluster: RayClusterConfig = Field(
         default_factory=RayClusterConfig, description="Kubernetes `RayCluster` CR configuration."
     )
-    client: RayClusterClient = Field(  # pyright: ignore[reportAssignmentType]
+    client: dg.ResourceDependency[RayClusterClient] = Field(  # pyright: ignore[reportAssignmentType]
         default_factory=RayClusterClient, description="Kubernetes `RayCluster` client"
     )
     log_cluster_conditions: bool = Field(

--- a/dagster_ray/kuberay/resources/raycluster.py
+++ b/dagster_ray/kuberay/resources/raycluster.py
@@ -32,14 +32,14 @@ if TYPE_CHECKING:
 
 
 @beta
-class RayClusterClientResource(dg.ConfigurableResource[RayClusterClient]):
+class KubeRayClusterClientResource(dg.ConfigurableResource[RayClusterClient]):
     kube_context: str | None = None
     kubeconfig_file: str | None = None
 
     def create_resource(self, context: InitResourceContext) -> RayClusterClient:
         load_kubeconfig(context=self.kube_context, config_file=self.kubeconfig_file)
 
-        return RayClusterClient(context=self.kube_context, config_file=self.kubeconfig_file)
+        return RayClusterClient(context=self.kube_context, kubeconfig_file=self.kubeconfig_file)
 
 
 @beta
@@ -52,7 +52,7 @@ class KubeRayCluster(BaseKubeRayResourceConfig, BaseRayResource):
         default_factory=RayClusterConfig, description="Kubernetes `RayCluster` CR configuration."
     )
     client: dg.ResourceDependency[RayClusterClient] = Field(  # pyright: ignore[reportAssignmentType]
-        default_factory=RayClusterClientResource, description="Kubernetes `RayCluster` client"
+        default_factory=RayClusterClient, description="Kubernetes `RayCluster` client"
     )
     log_cluster_conditions: bool = Field(
         default=True,

--- a/dagster_ray/kuberay/resources/raycluster.py
+++ b/dagster_ray/kuberay/resources/raycluster.py
@@ -43,7 +43,7 @@ class KubeRayClusterClientResource(dg.ConfigurableResource[RayClusterClient]):
 
 
 @beta
-class KubeRayCluster(BaseKubeRayResourceConfig, BaseRayResource):
+class KubeRayCluster(BaseRayResource, BaseKubeRayResourceConfig):
     """
     Provides a `RayCluster` for Dagster steps.
     """

--- a/dagster_ray/kuberay/resources/raycluster.py
+++ b/dagster_ray/kuberay/resources/raycluster.py
@@ -51,7 +51,7 @@ class KubeRayCluster(BaseKubeRayResourceConfig, BaseRayResource):
     ray_cluster: RayClusterConfig = Field(
         default_factory=RayClusterConfig, description="Kubernetes `RayCluster` CR configuration."
     )
-    client: dg.ResourceDependency[RayClusterClient] = Field(  # pyright: ignore[reportAssignmentType]
+    client: RayClusterClient = Field(  # pyright: ignore[reportAssignmentType]
         default_factory=RayClusterClient, description="Kubernetes `RayCluster` client"
     )
     log_cluster_conditions: bool = Field(

--- a/dagster_ray/kuberay/resources/rayjob.py
+++ b/dagster_ray/kuberay/resources/rayjob.py
@@ -42,7 +42,7 @@ class InteractiveRayJobConfig(RayJobConfig):
 
 
 @beta
-class KubeRayInteractiveJob(BaseKubeRayResourceConfig, BaseRayResource):
+class KubeRayInteractiveJob(BaseRayResource, BaseKubeRayResourceConfig):
     """
     Provides a `RayJob` for Dagster steps.
     """

--- a/dagster_ray/kuberay/resources/rayjob.py
+++ b/dagster_ray/kuberay/resources/rayjob.py
@@ -30,7 +30,7 @@ class KubeRayJobClientResource(dg.ConfigurableResource[RayJobClient]):
     def create_resource(self, context: InitResourceContext) -> RayJobClient:
         load_kubeconfig(context=self.kube_context, config_file=self.kubeconfig_file)
 
-        return RayJobClient(context=self.kube_context, config_file=self.kubeconfig_file)
+        return RayJobClient(context=self.kube_context, kubeconfig_file=self.kubeconfig_file)
 
 
 class InteractiveRayJobSpec(RayJobSpec):
@@ -51,7 +51,7 @@ class KubeRayInteractiveJob(BaseKubeRayResourceConfig, BaseRayResource):
         default_factory=InteractiveRayJobConfig, description="Configuration for the Kubernetes `RayJob` CR"
     )
     client: dg.ResourceDependency[RayJobClient] = Field(  # pyright: ignore[reportAssignmentType]
-        default_factory=KubeRayJobClientResource, description="Kubernetes `RayJob` client"
+        default_factory=RayJobClient, description="Kubernetes `RayJob` client"
     )
 
     log_cluster_conditions: bool = Field(

--- a/dagster_ray/kuberay/resources/rayjob.py
+++ b/dagster_ray/kuberay/resources/rayjob.py
@@ -50,7 +50,7 @@ class KubeRayInteractiveJob(BaseKubeRayResourceConfig, BaseRayResource):
     ray_job: InteractiveRayJobConfig = Field(
         default_factory=InteractiveRayJobConfig, description="Configuration for the Kubernetes `RayJob` CR"
     )
-    client: dg.ResourceDependency[RayJobClient] = Field(  # pyright: ignore[reportAssignmentType]
+    client: RayJobClient = Field(  # pyright: ignore[reportAssignmentType]
         default_factory=RayJobClient, description="Kubernetes `RayJob` client"
     )
 

--- a/dagster_ray/kuberay/resources/rayjob.py
+++ b/dagster_ray/kuberay/resources/rayjob.py
@@ -50,7 +50,7 @@ class KubeRayInteractiveJob(BaseKubeRayResourceConfig, BaseRayResource):
     ray_job: InteractiveRayJobConfig = Field(
         default_factory=InteractiveRayJobConfig, description="Configuration for the Kubernetes `RayJob` CR"
     )
-    client: RayJobClient = Field(  # pyright: ignore[reportAssignmentType]
+    client: dg.ResourceDependency[RayJobClient] = Field(  # pyright: ignore[reportAssignmentType]
         default_factory=RayJobClient, description="Kubernetes `RayJob` client"
     )
 

--- a/tests/kuberay/conftest.py
+++ b/tests/kuberay/conftest.py
@@ -183,7 +183,7 @@ def k8s_with_raycluster(
     config.load_kube_config(str(k8s_with_kuberay.kubeconfig))
 
     client = RayClusterClient(
-        config_file=str(k8s_with_kuberay.kubeconfig),
+        kubeconfig_file=str(k8s_with_kuberay.kubeconfig),
     )
 
     client.create(

--- a/tests/kuberay/test_interactive_rayjob.py
+++ b/tests/kuberay/test_interactive_rayjob.py
@@ -13,9 +13,12 @@ from dagster_ray.kuberay import (
     KubeRayCluster,
     KubeRayInteractiveJob,
 )
-from dagster_ray.kuberay.client.rayjob.client import RayJobClient
 from dagster_ray.kuberay.configs import RayClusterSpec
-from dagster_ray.kuberay.resources.rayjob import InteractiveRayJobConfig, InteractiveRayJobSpec
+from dagster_ray.kuberay.resources.rayjob import (
+    InteractiveRayJobConfig,
+    InteractiveRayJobSpec,
+    KubeRayJobClientResource,
+)
 from tests.kuberay.utils import NAMESPACE, get_random_free_port
 
 MIN_KUBERAY_VERSION = "1.3.0"
@@ -34,7 +37,7 @@ def interactive_rayjob_resource(
 
     return KubeRayInteractiveJob(
         image=dagster_ray_image,
-        client=RayJobClient(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
+        client=KubeRayJobClientResource(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
         ray_job=InteractiveRayJobConfig(
             metadata={"namespace": NAMESPACE},
             spec=InteractiveRayJobSpec(

--- a/tests/kuberay/test_interactive_rayjob.py
+++ b/tests/kuberay/test_interactive_rayjob.py
@@ -34,7 +34,7 @@ def interactive_rayjob_resource(
 
     return KubeRayInteractiveJob(
         image=dagster_ray_image,
-        client=RayJobClient(config_file=str(k8s_with_kuberay.kubeconfig)),
+        client=RayJobClient(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
         ray_job=InteractiveRayJobConfig(
             metadata={"namespace": NAMESPACE},
             spec=InteractiveRayJobSpec(

--- a/tests/kuberay/test_pipes.py
+++ b/tests/kuberay/test_pipes.py
@@ -67,7 +67,7 @@ RAY_JOB = {
 def pipes_kube_rayjob_client(k8s_with_kuberay: AClusterManager):
     return PipesKubeRayJobClient(
         client=RayJobClient(
-            config_file=str(k8s_with_kuberay.kubeconfig),
+            kubeconfig_file=str(k8s_with_kuberay.kubeconfig),
         ),
         port_forward=True,
     )

--- a/tests/kuberay/test_raycluster.py
+++ b/tests/kuberay/test_raycluster.py
@@ -8,7 +8,7 @@ from dagster import AssetExecutionContext, RunConfig, asset, materialize_to_memo
 from pytest_kubernetes.providers import AClusterManager
 
 from dagster_ray import Lifecycle, RayResource
-from dagster_ray.kuberay import KubeRayCluster, RayClusterClientResource, RayClusterConfig, cleanup_kuberay_clusters
+from dagster_ray.kuberay import KubeRayCluster, KubeRayClusterClientResource, RayClusterConfig, cleanup_kuberay_clusters
 from dagster_ray.kuberay.client import RayClusterClient
 from dagster_ray.kuberay.configs import RayClusterSpec
 from dagster_ray.kuberay.ops import CleanupKuberayClustersConfig
@@ -29,7 +29,7 @@ def ray_cluster_resource(
         # have have to first run port-forwarding with minikube
         # we can only init ray after that
         lifecycle=Lifecycle(connect=False),
-        client=RayClusterClientResource(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
+        client=RayClusterClient(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
         ray_cluster=RayClusterConfig(
             metadata={"namespace": NAMESPACE},
             spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
@@ -55,7 +55,7 @@ def ray_cluster_resource_skip_cleanup(
             connect=False,
             cleanup="never",
         ),
-        client=RayClusterClientResource(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
+        client=RayClusterClient(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
         ray_cluster=RayClusterConfig(
             metadata={"namespace": NAMESPACE},
             spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
@@ -78,7 +78,7 @@ def ray_cluster_resource_skip_create(
         # have have to first run port-forwarding with minikube
         # we can only init ray after that
         lifecycle=Lifecycle(create=False),
-        client=RayClusterClientResource(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
+        client=RayClusterClient(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
         ray_cluster=RayClusterConfig(
             metadata={"namespace": NAMESPACE},
             spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
@@ -101,7 +101,7 @@ def ray_cluster_resource_skip_wait(
         # have have to first run port-forwarding with minikube
         # we can only init ray after that
         lifecycle=Lifecycle(wait=False),
-        client=RayClusterClientResource(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
+        client=RayClusterClient(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
         ray_cluster=RayClusterConfig(
             metadata={"namespace": NAMESPACE},
             spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
@@ -163,7 +163,7 @@ def test_kuberay_cluster_resource(
         resources={"ray_cluster": ray_cluster_resource},
     )
 
-    kuberay_client = RayClusterClient(config_file=str(k8s_with_kuberay.kubeconfig))
+    kuberay_client = RayClusterClient(kubeconfig_file=str(k8s_with_kuberay.kubeconfig))
 
     # make sure the RayCluster is cleaned up
 
@@ -237,7 +237,7 @@ def test_kuberay_cleanup_job(
         resources={"ray_cluster": ray_cluster_resource_skip_cleanup},
     )
 
-    kuberay_client = RayClusterClient(config_file=str(k8s_with_kuberay.kubeconfig))
+    kuberay_client = RayClusterClient(kubeconfig_file=str(k8s_with_kuberay.kubeconfig))
 
     assert (
         len(
@@ -251,7 +251,7 @@ def test_kuberay_cleanup_job(
 
     cleanup_kuberay_clusters.execute_in_process(
         resources={
-            "kuberay_client": RayClusterClientResource(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
+            "kuberay_client": KubeRayClusterClientResource(kubeconfig_file=str(k8s_with_kuberay.kubeconfig)),
         },
         run_config=RunConfig(
             ops={

--- a/tests/kuberay/test_raycluster.py
+++ b/tests/kuberay/test_raycluster.py
@@ -136,9 +136,7 @@ def ensure_kuberay_cluster_correctness(
         # not in localhost
         assert ray_cluster.cluster_name in ray.get(get_hostname.remote())
 
-        ray_cluster_description = ray_cluster.client.client.get(
-            ray_cluster.cluster_name, namespace=ray_cluster.namespace
-        )
+        ray_cluster_description = ray_cluster.client.get(ray_cluster.cluster_name, namespace=ray_cluster.namespace)
         assert ray_cluster_description["metadata"]["labels"]["dagster/run-id"] == context.run_id
 
 


### PR DESCRIPTION
- remove redundant attributes and properties
- use `dg.ResourceParam`  and `create_resource` to produce the clients directly
- rename `config_file` to `kubeconfig_file` for consistency