### PR TITLE
:sparkles:  `on_exception` cleanup option + RayJob cleanup

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -40,14 +40,6 @@
         ],
         "./dagster_ray/resources.py": [
             {
-                "code": "reportUnreachable",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUnusedImport",
                 "range": {
                     "startColumn": 47,

--- a/CHANDELOG.md
+++ b/CHANDELOG.md
@@ -11,12 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `KubeRayInteractiveJob.deletion_strategy` now defaults to `DeleteCluster` for both successful and failed executions. This is a reasonable default for the use case.
 - `KubeRayInteractiveJob.ttl_seconds_after_finished` now defaults to `600` seconds.
 - `KubeRayCluster.lifecycle.cleanup` now defaults to `always`
-- `KubeRayJob.lifecycle.cleanup` now defaults to `on_interrupt`. Users are advised to rely on built-in `RayJob` cleanup mechanisms, such as `ttlSecondsAfterFinished` and `deletionStrategy`.
 
 # Added
 - new `enable_legacy_debugger` configuration parameter to subclasses of `RayResource`
-- new `on_interrupt` option for `lifecycle.cleanup` policy
-- `KubeRayInteractiveJob` now respects `lifecycle.cleanup`
+- new `on_exception` option for `lifecycle.cleanup` policy. It's triggered during resource setup/cleanup (including `KeyboardInterrupt`), but not by user `@op`/`@asset` code.
+- `KubeRayInteractiveJob` now respects `lifecycle.cleanup`. It defaults to `on_exception`. Users are advised to rely on built-in `RayJob` cleanup mechanisms, such as `ttlSecondsAfterFinished` and `deletionStrategy`.
 
 ## Fixes
 - removed `ignore_reinit_error` from `RayResource` init options: it's potentially dangerous, for example in case the user has accidentally connected to another Ray cluster (including local ray) before initializing the resource.

--- a/CHANDELOG.md
+++ b/CHANDELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- added `enable_legacy_debugger` configuration parameter to subclasses of `RayResource`
+# Changed
+- `KubeRayInteractiveJob.deletion_strategy` now defaults to `DeleteCluster` for both successful and failed executions. This is a reasonable default for the use case.
+- `KubeRayInteractiveJob.ttl_seconds_after_finished` now defaults to `600` seconds.
+- `KubeRayCluster.lifecycle.cleanup` now defaults to `always`
+- `KubeRayJob.lifecycle.cleanup` now defaults to `on_interrupt`. Users are advised to rely on built-in `RayJob` cleanup mechanisms, such as `ttlSecondsAfterFinished` and `deletionStrategy`.
+
+# Added
+- new `enable_legacy_debugger` configuration parameter to subclasses of `RayResource`
+- new `on_interrupt` option for `lifecycle.cleanup` policy
+- `KubeRayInteractiveJob` now respects `lifecycle.cleanup`
 
 ## Fixes
 - removed `ignore_reinit_error` from `RayResource` init options: it's potentially dangerous, for example in case the user has accidentally connected to another Ray cluster (including local ray) before initializing the resource.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-#syntax=docker/dockerfile:1.17
-
 # options: prod,dev
 ARG BUILD_DEPENDENCIES=prod
 ARG PYTHON_VERSION=3.11.7

--- a/dagster_ray/_base/resources.py
+++ b/dagster_ray/_base/resources.py
@@ -36,8 +36,9 @@ class Lifecycle(dg.Config):
         default=True,
         description="Whether to run `ray.init` against the remote Ray cluster. If set to `False`, the user can manually call `.connect` instead.",
     )
-    cleanup: Literal["never", "except_failure", "always"] = Field(
-        default="always", description="Whether to delete the resource after Dagster step completion."
+    cleanup: Literal["never", "except_failure", "always", "on_interrupt"] = Field(
+        default="always",
+        description="Resource cleanup policy. Determines when the resource should be deleted after Dagster step execution or during interruption.",
     )
 
 

--- a/dagster_ray/_base/resources.py
+++ b/dagster_ray/_base/resources.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import contextlib
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Literal, Union, cast
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
 
 import dagster as dg
 from dagster import AssetExecutionContext, ConfigurableResource, InitResourceContext, OpExecutionContext
@@ -11,10 +13,11 @@ from pydantic import Field, PrivateAttr
 # https://github.com/ray-project/kuberay/issues/2078
 from requests.exceptions import ConnectionError
 from tenacity import retry, retry_if_exception_type, stop_after_delay
-from typing_extensions import TypeAlias
+from typing_extensions import Self, TypeAlias
 
 from dagster_ray._base.utils import get_dagster_tags
 from dagster_ray.config import RayDataExecutionOptions
+from dagster_ray.types import AnyDagsterContext
 from dagster_ray.utils import _process_dagster_env_vars, get_current_job_id
 
 if TYPE_CHECKING:
@@ -36,7 +39,7 @@ class Lifecycle(dg.Config):
         default=True,
         description="Whether to run `ray.init` against the remote Ray cluster. If set to `False`, the user can manually call `.connect` instead.",
     )
-    cleanup: Literal["never", "except_failure", "always", "on_interrupt"] = Field(
+    cleanup: Literal["never", "always", "on_exception"] = Field(
         default="always",
         description="Resource cleanup policy. Determines when the resource should be deleted after Dagster step execution or during interruption.",
     )
@@ -49,7 +52,7 @@ class BaseRayResource(ConfigurableResource, ABC):
     """
 
     lifecycle: Lifecycle = Field(default_factory=Lifecycle, description="Actions to perform during resource setup.")
-
+    timeout: float = Field(default=600.0, description="Timeout for Ray readiness in seconds")
     ray_init_options: dict[str, Any] = Field(
         default_factory=dict,
         description="Additional keyword arguments to pass to `ray.init()` call, such as `runtime_env`, `num_cpus`, etc. Dagster's `EnvVar` is supported. More details in [Ray docs](https://docs.ray.io/en/latest/ray-core/api/doc/ray.init.html).",
@@ -94,6 +97,15 @@ class BaseRayResource(ConfigurableResource, ABC):
         raise NotImplementedError()
 
     @property
+    @abstractmethod
+    def name(self) -> str:
+        raise NotImplementedError()
+
+    @property
+    def display_name(self) -> str:
+        return self.name
+
+    @property
     def ray_address(self) -> str:
         return f"ray://{self.host}:{self.redis_port}"
 
@@ -109,14 +121,63 @@ class BaseRayResource(ConfigurableResource, ABC):
         """
         return get_current_job_id()
 
-    def create(self, context: InitResourceContext | OpOrAssetExecutionContext):
+    @contextlib.contextmanager
+    def yield_for_execution(self, context: InitResourceContext) -> Generator[Self, None, None]:
+        exception_occurred = None
+        try:
+            if self.lifecycle.create:
+                self._create(context)
+                if self.lifecycle.wait:
+                    self._wait(context)
+                    if self.lifecycle.connect:
+                        self._connect(context)
+            yield self
+        except BaseException as e:
+            exception_occurred = e
+            raise
+        finally:
+            self.cleanup(context, exception_occurred)
+
+    def _create(self, context: AnyDagsterContext):
+        assert context.log is not None
+        if not self.created:
+            try:
+                self.create(context)
+                context.log.info(f"Created {self.display_name}.")
+            except BaseException:
+                context.log.exception(f"Failed to create {self.display_name}")
+                raise
+
+    def _wait(self, context: AnyDagsterContext):
+        assert context.log is not None
+        self._create(context)
+        if not self.ready:
+            context.log.info(f"Waiting for {self.display_name} to become ready (timeout={self.timeout:.0f}s)...")
+            try:
+                self.wait(context)
+            except BaseException:
+                context.log.exception(f"Failed to wait for {self.display_name} readiness")
+                raise
+
+    def _connect(self, context: AnyDagsterContext):
+        assert context.log is not None
+        self._wait(context)
+        if not self.connected:
+            try:
+                self.connect(context)
+            except BaseException:
+                context.log.exception(f"Failed to connect to {self.display_name}")
+                raise
+            context.log.info(f"Initialized Ray Client with {self.display_name}")
+
+    def create(self, context: AnyDagsterContext):
         pass
 
-    def wait(self, context: InitResourceContext | OpOrAssetExecutionContext):
+    def wait(self, context: AnyDagsterContext):
         pass
 
     @retry(stop=stop_after_delay(120), retry=retry_if_exception_type(ConnectionError), reraise=True)
-    def connect(self, context: OpOrAssetExecutionContext | InitResourceContext) -> RayBaseContext:
+    def connect(self, context: AnyDagsterContext) -> RayBaseContext:
         assert context.log is not None
 
         import ray
@@ -130,6 +191,12 @@ class BaseRayResource(ConfigurableResource, ABC):
                 k: v for k, v in init_options["runtime_env"]["env_vars"].items() if v is not None
             }
 
+        init_options["runtime_env"] = init_options.get("runtime_env", {})
+        init_options["runtime_env"]["env_vars"] = init_options["runtime_env"].get("env_vars", {})
+
+        for var, value in self.get_env_vars_to_inject().items():
+            init_options["runtime_env"]["env_vars"][var] = value
+
         self.data_execution_options.apply()
 
         self._context = ray.init(
@@ -140,6 +207,30 @@ class BaseRayResource(ConfigurableResource, ABC):
         self.data_execution_options.apply_remote()
         context.log.info("Initialized Ray in client mode!")
         return cast("RayBaseContext", self._context)
+
+    def delete(self, context: AnyDagsterContext):
+        pass
+
+    def cleanup(self, context: AnyDagsterContext, exception: Optional[BaseException]):  # noqa: UP007
+        assert context.log is not None
+
+        if self.lifecycle.cleanup == "never":
+            to_delete = False
+        elif not self.created:
+            to_delete = False
+        elif self.lifecycle.cleanup == "always":
+            to_delete = True
+        elif self.lifecycle.cleanup == "on_exception":
+            to_delete = exception is not None
+        else:
+            to_delete = False
+
+        if to_delete:
+            self.delete(context)
+            context.log.info(f'Deleted {self.display_name} according to cleanup policy "{self.lifecycle.cleanup}"')
+
+        if self.connected and hasattr(self, "_context") and self._context is not None:
+            self._context.disconnect()
 
     def get_dagster_tags(self, context: InitResourceContext | OpOrAssetExecutionContext) -> dict[str, str]:
         tags = get_dagster_tags(context)
@@ -157,3 +248,15 @@ class BaseRayResource(ConfigurableResource, ABC):
         if self.enable_legacy_debugger:
             vars["RAY_DEBUG"] = "legacy"
         return vars
+
+    @property
+    def created(self) -> bool:
+        return hasattr(self, "_name") and self._name is not None
+
+    @property
+    def ready(self) -> bool:
+        return hasattr(self, "_host") and self._host is not None
+
+    @property
+    def connected(self) -> bool:
+        return hasattr(self, "_context") and self._context is not None

--- a/dagster_ray/kuberay/configs.py
+++ b/dagster_ray/kuberay/configs.py
@@ -200,7 +200,9 @@ class RayJobSpec(dg.PermissiveConfig):
     metadata: dict[str, Any] | None = None
     cluster_selector: dict[str, str] | None = None
     managed_by: str | None = None
-    deletion_strategy: dict[str, Any] | None = None
+    deletion_strategy: dict[str, Any] | None = Field(
+        default_factory=lambda: {"onFailure": {"policy": "DeleteCluster"}, "onSuccess": {"policy": "DeleteCluster"}}
+    )
     runtime_env_yaml: str | None = None
     job_id: str | None = None
     submission_mode: Literal["K8sJobMode", "HTTPMode", "InteractiveMode"] = "K8sJobMode"
@@ -208,7 +210,7 @@ class RayJobSpec(dg.PermissiveConfig):
     entrypoint_num_cpus: float | None = None
     entrypoint_memory: float | None = None
     entrypoint_num_gpus: float | None = None
-    ttl_seconds_after_finished: int | None = 60 * 60  # 1 hour
+    ttl_seconds_after_finished: int | None = 5 * 60  # 5 minutes
     shutdown_after_job_finishes: bool = True
     suspend: bool | None = None
 

--- a/dagster_ray/kuberay/resources/base.py
+++ b/dagster_ray/kuberay/resources/base.py
@@ -26,16 +26,9 @@ class BaseKubeRayResourceConfig(Config):
         default=DEFAULT_DEPLOYMENT_NAME,
         description="Dagster deployment name. Is used as a prefix for the Kubernetes resource name. Dagster Cloud variables are used to determine the default value.",
     )
-    timeout: float = Field(default=600, description="Readiness timeout in seconds")
     poll_interval: float = Field(default=1.0, description="Poll interval for various API requests")
 
-    _cluster_name: str = PrivateAttr()
     _host: str = PrivateAttr()
-
-    @property
-    @abstractmethod
-    def cluster_name(self) -> str:
-        raise NotImplementedError
 
     @property
     @abstractmethod

--- a/dagster_ray/kuberay/resources/raycluster.py
+++ b/dagster_ray/kuberay/resources/raycluster.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import contextlib
 import sys
-from collections.abc import Generator
 from typing import TYPE_CHECKING
 
 from dagster import ConfigurableResource, InitResourceContext
@@ -14,11 +12,12 @@ from dagster_ray.kuberay.client import RayClusterClient
 from dagster_ray.kuberay.configs import RayClusterConfig
 from dagster_ray.kuberay.resources.base import BaseKubeRayResourceConfig
 from dagster_ray.kuberay.utils import normalize_k8s_label_values
+from dagster_ray.types import AnyDagsterContext
 
 if sys.version_info >= (3, 11):
-    from typing import Self
+    pass
 else:
-    from typing_extensions import Self
+    pass
 
 from ray._private.worker import BaseContext as RayBaseContext  # noqa
 
@@ -87,7 +86,7 @@ class KubeRayCluster(BaseKubeRayResourceConfig, BaseRayResource):
         description="Whether to log RayCluster conditions while waiting for the RayCluster to become ready. For more information, see https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/observability.html#raycluster-status-conditions.",
     )
 
-    _cluster_name: str = PrivateAttr()
+    _name: str = PrivateAttr()
     _host: str = PrivateAttr()
 
     @property
@@ -97,138 +96,79 @@ class KubeRayCluster(BaseKubeRayResourceConfig, BaseRayResource):
         return self._host
 
     @property
-    def cluster_name(self) -> str:
-        if not hasattr(self, "_cluster_name") and self.ray_cluster.metadata.get("name") is None:
+    def name(self) -> str:
+        if not hasattr(self, "_name") and self.ray_cluster.metadata.get("name") is None:
             raise ValueError(f"{self.__class__.__name__} not initialized")
         elif (name := self.ray_cluster.metadata.get("name")) is not None:
             return name
         else:
-            return self._cluster_name
-
-    @property
-    def created(self) -> bool:
-        return hasattr(self, "_cluster_name")
-
-    @property
-    def ready(self) -> bool:
-        return hasattr(self, "_host")
+            return self._name
 
     @property
     def namespace(self) -> str:
         return self.ray_cluster.namespace
+
+    @property
+    @override
+    def display_name(self) -> str:
+        return (
+            f"RayCluster {self.namespace}/{self.name}" if self.created else f"RayCluster in namespace {self.namespace}"
+        )
 
     def get_dagster_tags(self, context: InitResourceContext | OpOrAssetExecutionContext) -> dict[str, str]:
         tags = super().get_dagster_tags(context=context)
         tags.update({"dagster/deployment": self.deployment_name})
         return tags
 
-    @contextlib.contextmanager
-    def yield_for_execution(self, context: InitResourceContext) -> Generator[Self, None, None]:
-        assert context.log is not None
-        assert context.dagster_run is not None
-
-        try:
-            if self.lifecycle.create:
-                self.create(context)
-                if self.lifecycle.wait:
-                    self.wait(context)
-                    if self.lifecycle.connect:
-                        self.connect(context)
-
-            yield self
-
-            self.cleanup(context, None)
-
-            if hasattr(self, "_context") and self._context is not None:
-                self._context.disconnect()
-        except BaseException as e:
-            self.cleanup(context, e)
-            raise e
-
     @override
     def create(self, context: InitResourceContext | OpOrAssetExecutionContext):
         assert context.log is not None
         assert context.dagster_run is not None
 
-        self._cluster_name = self.ray_cluster.metadata.get("name") or self._get_step_name(context)
+        self._name = self.ray_cluster.metadata.get("name") or self._get_step_name(context)
 
-        try:
-            # just a safety measure, no need to recreate the cluster for step retries or smth
-            if not self.client.client.get(
-                name=self.cluster_name,
-                namespace=self.namespace,
-            ):
-                k8s_manifest = self.ray_cluster.to_k8s(
-                    context,
-                    image=(self.image or context.dagster_run.tags.get("dagster/image")),
-                    labels=normalize_k8s_label_values(self.get_dagster_tags(context)),
-                    env_vars=self.get_env_vars_to_inject(),
-                )
+        # just a safety measure, no need to recreate the cluster for step retries or smth
+        if not self.client.client.get(
+            name=self.name,
+            namespace=self.namespace,
+        ):
+            k8s_manifest = self.ray_cluster.to_k8s(
+                context,
+                image=(self.image or context.dagster_run.tags.get("dagster/image")),
+                labels=normalize_k8s_label_values(self.get_dagster_tags(context)),
+                env_vars=self.get_env_vars_to_inject(),
+            )
 
-                k8s_manifest["metadata"]["name"] = self.cluster_name
+            k8s_manifest["metadata"]["name"] = self.name
 
-                resource = self.client.client.create(body=k8s_manifest, namespace=self.namespace)
-                if not resource:
-                    raise RuntimeError(f"Couldn't create RayCluster {self.namespace}/{self.cluster_name}")
+            resource = self.client.client.create(body=k8s_manifest, namespace=self.namespace)
+            if not resource:
+                raise RuntimeError(f"Couldn't create {self.display_name}")
 
-                context.log.info(f"Created RayCluster {self.namespace}/{self.cluster_name}.")
-        except BaseException:
-            context.log.critical(f"Couldn't create RayCluster {self.namespace}/{self.cluster_name}!")
-            raise
-
+    @override
     def wait(self, context: InitResourceContext | OpOrAssetExecutionContext):
         assert context.log is not None
         assert context.dagster_run is not None
 
-        try:
-            context.log.info(
-                f"Waiting for RayCluster {self.namespace}/{self.cluster_name} to become ready (timeout={self.timeout:.0f}s)..."
-            )
-            self._wait_raycluster_ready()
-
-            self._host = self.client.client.get_status(
-                name=self.cluster_name, namespace=self.namespace, timeout=self.timeout, poll_interval=self.poll_interval
-            )[  # pyright: ignore
-                "head"
-            ]["serviceIP"]
-
-            msg = f"RayCluster {self.namespace}/{self.cluster_name} is ready! Connection command:\n"
-            msg += f"kubectl -n {self.namespace} port-forward svc/{self.cluster_name}-head-svc 8265:8265 6379:6379 10001:10001"
-
-            context.log.info(msg)
-
-        except BaseException as e:
-            context.log.critical(f"Couldn't connect to RayCluster {self.namespace}/{self.cluster_name}!")
-            self.cleanup(context, e)
-            raise e
-
-    def _wait_raycluster_ready(self):
         self.client.client.wait_until_ready(
-            self.cluster_name,
+            self.name,
             namespace=self.namespace,
             timeout=self.timeout,
             poll_interval=self.poll_interval,
             log_cluster_conditions=self.log_cluster_conditions,
         )
 
-    def cleanup(self, context: InitResourceContext | OpOrAssetExecutionContext, exception: BaseException | None):
-        assert context.log is not None
+        self._host = self.client.client.get_status(
+            name=self.name, namespace=self.namespace, timeout=self.timeout, poll_interval=self.poll_interval
+        )[  # pyright: ignore
+            "head"
+        ]["serviceIP"]
 
-        if self.lifecycle.cleanup == "never":
-            to_delete = False
-        elif not self.created:
-            to_delete = False
-        elif self.lifecycle.cleanup == "always":
-            to_delete = True
-        elif self.lifecycle.cleanup == "except_failure" and exception is None:
-            to_delete = True
-        elif self.lifecycle.cleanup == "on_interrupt" and isinstance(exception, KeyboardInterrupt):
-            to_delete = True
-        else:
-            to_delete = False
+        msg = f"RayCluster {self.namespace}/{self.name} is ready! Connection command:\n"
+        msg += f"kubectl -n {self.namespace} port-forward svc/{self.name}-head-svc 8265:8265 6379:6379 10001:10001"
 
-        if to_delete:
-            self.client.client.delete(self.cluster_name, namespace=self.namespace)
-            context.log.info(
-                f'Deleted RayCluster {self.namespace}/{self.cluster_name} according to cleanup policy "{self.lifecycle.cleanup}"'
-            )
+        context.log.info(msg)
+
+    @override
+    def delete(self, context: AnyDagsterContext):
+        self.client.client.delete(self.name, namespace=self.namespace)

--- a/dagster_ray/resources.py
+++ b/dagster_ray/resources.py
@@ -1,18 +1,13 @@
-import contextlib
-import os
 import sys
-from collections.abc import Generator
-
-from dagster import InitResourceContext
 
 # yes, `python-client` is actually the KubeRay package name
 # https://github.com/ray-project/kuberay/issues/2078
 
 
 if sys.version_info >= (3, 11):
-    from typing import Self
+    pass
 else:
-    from typing_extensions import Self
+    pass
 
 from ray._private.worker import BaseContext as RayBaseContext  # noqa
 
@@ -36,23 +31,6 @@ class LocalRay(BaseRayResource):
     def ray_address(self) -> None:  # type: ignore
         return None
 
-    @contextlib.contextmanager
-    def yield_for_execution(self, context: InitResourceContext) -> Generator[Self, None, None]:
-        assert context.log is not None
-        assert context.dagster_run is not None
-
-        env_vars_to_inject = self.get_env_vars_to_inject()
-
-        if env_vars_to_inject:
-            context.log.warning("Setting debugging environment variables prior to starting Ray")
-            for key, value in env_vars_to_inject.items():
-                os.environ[key] = value
-
-        context.log.debug("Connecting to a local Ray cluster...")
-
-        self.connect(context)
-
-        yield self
-
-        if hasattr(self, "_context") and self._context is not None:
-            self._context.disconnect()
+    @property
+    def name(self) -> str:
+        return "LocalRay"

--- a/dagster_ray/resources.py
+++ b/dagster_ray/resources.py
@@ -54,5 +54,5 @@ class LocalRay(BaseRayResource):
 
         yield self
 
-        if self._context is not None:
+        if hasattr(self, "_context") and self._context is not None:
             self._context.disconnect()

--- a/dagster_ray/types.py
+++ b/dagster_ray/types.py
@@ -1,0 +1,6 @@
+from typing import Union
+
+import dagster as dg
+from typing_extensions import TypeAlias
+
+AnyDagsterContext: TypeAlias = Union[dg.OpExecutionContext, dg.AssetExecutionContext, dg.InitResourceContext]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,11 @@ exclude = [
 ]
 [tool.ruff.lint]
 extend-select = ["I", "TID252", "TID253", "UP", "FA100", "FA102", "PYI044", "F404"]
+ignore = [
+    "FA100",  # from __future__ import annotations breaks pydantic
+    "FA102" # from __future__ import annotations breaks pydantic
+]
+
 [tool.ruff.lint.isort]
 known-first-party = ["dagster_ray", "tests"]
 

--- a/tests/kuberay/conftest.py
+++ b/tests/kuberay/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import subprocess
 import sys
@@ -18,6 +19,8 @@ from dagster_ray.kuberay.client import RayClusterClient
 from dagster_ray.kuberay.configs import DEFAULT_HEAD_GROUP_SPEC, DEFAULT_WORKER_GROUP_SPECS
 from tests import ROOT_DIR
 from tests.kuberay.utils import NAMESPACE
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
@@ -49,7 +52,7 @@ def dagster_ray_image():
         ray_version = ray.__version__
         dagster_version = dagster.__version__
 
-        image = f"local/dagster-ray:py-{python_version}-{ray_version}-{dagster_version}"
+        image = f"local.io/registry/dagster-ray:py-{python_version}-{ray_version}-{dagster_version}"
 
         subprocess.run(
             [
@@ -77,12 +80,9 @@ def dagster_ray_image():
     return image
 
 
-# TODO: it's easy to parametrize over different versions of k8s
-# but it would take quite some time to test all of them!
-# probably should only do it in CI
 KUBERNETES_VERSION = os.getenv("PYTEST_KUBERNETES_VERSION", "1.31.0")
-
-KUBERAY_VERSIONS = os.getenv("PYTEST_KUBERAY_VERSIONS", "1.2.2").split(",")
+KUBERAY_VERSIONS = os.getenv("PYTEST_KUBERAY_VERSIONS", "1.4.0").split(",")
+KUBERNETES_CONTEXT = "pytest-dagster-ray"
 
 
 @pytest_cases.fixture(scope="session")  # type: ignore
@@ -95,8 +95,8 @@ def kuberay_version(kuberay_version_param: str):
 def k8s_with_kuberay(
     request, kuberay_helm_repo, dagster_ray_image: str, kuberay_version: str
 ) -> Iterator[AClusterManager]:
-    k8s = select_provider_manager("minikube")("dagster-ray")
-    k8s.create(ClusterOptions(api_version=KUBERNETES_VERSION))
+    k8s = select_provider_manager("minikube")(KUBERNETES_CONTEXT[7:])  # strip pytest-
+    k8s.create(ClusterOptions(api_version=KUBERNETES_VERSION), cluster_timeout=600)
     # load images in advance to avoid possible timeouts later on
     k8s.load_image(f"quay.io/kuberay/operator:v{kuberay_version}")
 
@@ -107,7 +107,9 @@ def k8s_with_kuberay(
     with tempfile.TemporaryDirectory() as tmpdir:
         image_tar = Path(tmpdir) / "dagster-ray.tar"
         subprocess.run(["docker", "image", "save", "-o", str(image_tar), dagster_ray_image], check=True)
+        logger.info(f"Loading image {dagster_ray_image} into K8s...")
         k8s.load_image(str(image_tar))
+        logger.info(f"Image {dagster_ray_image} loaded.")
 
     # init the cluster with a workload
 
@@ -124,6 +126,8 @@ def k8s_with_kuberay(
         "kuberay/kuberay-operator",
         "--version",
         kuberay_version,
+        "--timeout",
+        "10m",
     ]
 
     if Version(kuberay_version) > Version("1.3.0"):
@@ -171,6 +175,7 @@ def worker_group_specs(dagster_ray_image: str) -> list[dict[str, Any]]:
 
 
 PERSISTENT_RAY_CLUSTER_NAME = "persistent-ray-cluster"
+RAYJOB_TIMEOUT = 45
 
 
 @pytest.fixture(scope="session")
@@ -180,11 +185,9 @@ def k8s_with_raycluster(
     worker_group_specs: list[dict[str, Any]],
 ) -> Iterator[tuple[dict[str, str], AClusterManager]]:
     # create a RayCluster
-    config.load_kube_config(str(k8s_with_kuberay.kubeconfig))
+    config.load_kube_config(str(k8s_with_kuberay.kubeconfig), context=KUBERNETES_CONTEXT)
 
-    client = RayClusterClient(
-        config_file=str(k8s_with_kuberay.kubeconfig),
-    )
+    client = RayClusterClient(config_file=str(k8s_with_kuberay.kubeconfig), context=KUBERNETES_CONTEXT)
 
     client.create(
         body={

--- a/tests/kuberay/conftest.py
+++ b/tests/kuberay/conftest.py
@@ -220,3 +220,26 @@ def k8s_with_raycluster(
         name=PERSISTENT_RAY_CLUSTER_NAME,
         namespace=NAMESPACE,
     )
+
+
+@pytest.fixture(autouse=True)
+def ray_shutdown():
+    """Ensure there is not existing Ray connection both before and after each test,
+
+    since all the tests in this module are using remote Ray clusters."""
+    try:
+        import ray
+
+        if ray.is_initialized():
+            ray.shutdown()
+    except ImportError:
+        pass
+
+    yield
+    try:
+        import ray
+
+        if ray.is_initialized():
+            ray.shutdown()
+    except ImportError:
+        pass

--- a/tests/kuberay/test_interactive_rayjob.py
+++ b/tests/kuberay/test_interactive_rayjob.py
@@ -1,5 +1,7 @@
 import socket
+import sys
 import time
+from pathlib import Path
 from typing import Any, Literal, cast
 
 import dagster as dg
@@ -18,6 +20,7 @@ from dagster_ray.kuberay import (
 from dagster_ray.kuberay.client.rayjob.client import RayJobClient
 from dagster_ray.kuberay.configs import RayClusterSpec
 from dagster_ray.kuberay.resources.rayjob import InteractiveRayJobConfig, InteractiveRayJobSpec
+from tests.kuberay.conftest import KUBERNETES_CONTEXT, RAYJOB_TIMEOUT
 from tests.kuberay.utils import NAMESPACE, get_random_free_port
 
 MIN_KUBERAY_VERSION = "1.3.0"
@@ -25,7 +28,7 @@ MIN_KUBERAY_VERSION = "1.3.0"
 
 @pytest.fixture(scope="session")
 def rayjob_client(k8s_with_kuberay: AClusterManager) -> RayJobClient:
-    return RayJobClient(config_file=str(k8s_with_kuberay.kubeconfig))
+    return RayJobClient(config_file=str(k8s_with_kuberay.kubeconfig), context=KUBERNETES_CONTEXT)
 
 
 def test_instantiate_defaults():
@@ -44,18 +47,18 @@ def test_no_lifecycle(dagster_instance: dg.DagsterInstance, rayjob_client: RayJo
     dg.materialize(assets=[my_asset], resources={"interactive_rayjob": interactive_rayjob}, instance=dagster_instance)
 
 
-@pytest.mark.parametrize("cleanup", ["always", "never", "except_failure", "on_interrupt"])
+@pytest.mark.parametrize("cleanup", ["always", "never"])
 @pytest.mark.parametrize("wait", [True, False])
-@pytest.mark.parametrize("interrupt", [True, False])
-@pytest.mark.slow
 def test_cleanup(
+    head_group_spec: dict[str, Any],
+    worker_group_specs: list[dict[str, Any]],
+    k8s_with_kuberay: AClusterManager,
     kuberay_version: str,
     dagster_instance: dg.DagsterInstance,
     rayjob_client: RayJobClient,
     dagster_ray_image: str,
     wait: bool,
-    cleanup: Literal["always", "never", "except_failure", "on_interrupt"],
-    interrupt: bool,
+    cleanup: Literal["always", "never", "on_exception"],
 ):
     if Version(kuberay_version) < Version(MIN_KUBERAY_VERSION):
         pytest.skip(f"KubeRay {MIN_KUBERAY_VERSION} is required to use interactive mode with RayJob")
@@ -66,14 +69,17 @@ def test_cleanup(
         redis_port=get_random_free_port(),
         ray_job=InteractiveRayJobConfig(
             metadata={"namespace": NAMESPACE},
+            spec=InteractiveRayJobSpec(
+                ray_cluster_spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
+            ),
         ),
         lifecycle=Lifecycle(create=True, wait=wait, connect=False, cleanup=cleanup),
+        timeout=RAYJOB_TIMEOUT,
     )
 
     @dg.asset
     def my_asset(interactive_rayjob: KubeRayInteractiveJob) -> None:
-        if interrupt:
-            raise KeyboardInterrupt("Intentional interruption")
+        return
 
     res = dg.materialize(
         assets=[my_asset],
@@ -82,24 +88,146 @@ def test_cleanup(
         raise_on_error=False,
     )
 
+    # Wait for cleanup to complete with retry mechanism
+    max_wait_time = 30  # seconds
+    wait_interval = 1  # seconds
+    start_time = time.time()
+
+    while time.time() - start_time < max_wait_time:
+        jobs = rayjob_client.list(
+            namespace=interactive_rayjob.namespace, label_selector=f"dagster/run-id={res.run_id}"
+        )["items"]
+
+        # Filter out jobs that are being deleted (have deletionTimestamp)
+        active_jobs = [job for job in jobs if job.get("metadata", {}).get("deletionTimestamp") is None]
+
+        if cleanup == "always" and len(active_jobs) == 0:
+            break
+        elif cleanup == "never" and len(active_jobs) == 1:
+            break
+
+        time.sleep(wait_interval)
+
+    # Final check
     jobs = rayjob_client.list(namespace=interactive_rayjob.namespace, label_selector=f"dagster/run-id={res.run_id}")[
         "items"
     ]
+    active_jobs = [job for job in jobs if job.get("metadata", {}).get("deletionTimestamp") is None]
 
     if cleanup == "always":
-        assert len(jobs) == 0
+        assert len(active_jobs) == 0, (
+            f"Expected 0 active jobs after cleanup, but found {len(active_jobs)} active jobs out of {len(jobs)} total jobs"
+        )
     elif cleanup == "never":
-        assert len(jobs) == 1
-    elif cleanup == "except_failure":
-        if res.success:
-            assert len(jobs) == 0
-        else:
-            assert len(jobs) == 1
-    elif cleanup == "on_interrupt":
-        if interrupt:
-            assert len(jobs) == 0
-        else:
-            assert len(jobs) == 1
+        assert len(active_jobs) == 1, (
+            f"Expected 1 active job when cleanup is disabled, but found {len(active_jobs)} active jobs out of {len(jobs)} total jobs"
+        )
+
+
+@pytest.mark.parametrize("cleanup", ["always", "on_exception"])
+def test_cleanup_on_interrupt(
+    head_group_spec: dict[str, Any],
+    worker_group_specs: list[dict[str, Any]],
+    k8s_with_kuberay: AClusterManager,
+    kuberay_version: str,
+    dagster_instance: dg.DagsterInstance,
+    rayjob_client: RayJobClient,
+    cleanup: str,
+):
+    import json
+    import signal
+    import subprocess
+
+    if Version(kuberay_version) < Version(MIN_KUBERAY_VERSION):
+        pytest.skip(f"KubeRay {MIN_KUBERAY_VERSION} is required to use interactive mode with RayJob")
+
+    # Path to the separate test script
+    # this should be a rela
+    script_path = str(Path(__file__).parents[1] / "scripts/launch_dagster_run_with_kuberay_interactive_job.py")
+
+    assert Path(script_path).exists()
+
+    # Build command line arguments
+    cmd_args = [
+        sys.executable,
+        script_path,
+        "--config-file",
+        str(k8s_with_kuberay.kubeconfig),
+        "--context",
+        KUBERNETES_CONTEXT,
+        "--image",
+        "invalid-image:nonexistent",  # this will cause the RayJob to hang, we need it to test the interrupt cleanup functionality
+        "--redis-port",
+        str(get_random_free_port()),
+        "--namespace",
+        NAMESPACE,
+        "--head-group-spec",
+        json.dumps(head_group_spec),
+        "--worker-group-specs",
+        json.dumps(worker_group_specs),
+        "--cleanup",
+        cleanup,
+    ]
+
+    # Start the subprocess with stdout capture
+    process = subprocess.Popen(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    # Wait a bit to let the RayJob get created
+    time.sleep(10)
+
+    # Interrupt the process
+    process.send_signal(signal.SIGTERM)
+
+    # Wait for process to terminate and capture output
+    try:
+        stdout, stderr = process.communicate(timeout=30)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        stdout, stderr = process.communicate()
+
+    # Extract run ID from stdout (last line should be the run ID)
+    assert stdout, "Expected to get stdout from the subprocess"
+    lines = stdout.strip().split("\n")
+    run_id = None
+    for line in reversed(lines):
+        if line.strip() and "-" in line.strip():  # Run IDs have dashes
+            run_id = line.strip()
+            break
+
+    assert run_id, f"Expected to get a run ID from subprocess output, got: {stdout}"
+
+    # Wait for cleanup to complete with retry mechanism
+    max_wait_time = 30  # seconds
+    wait_interval = 1  # seconds
+    start_time = time.time()
+
+    while time.time() - start_time < max_wait_time:
+        jobs = rayjob_client.list(namespace=NAMESPACE, label_selector=f"dagster/run-id={run_id}")["items"]
+
+        # Filter out jobs that are being deleted (have deletionTimestamp)
+        active_jobs = [job for job in jobs if job.get("metadata", {}).get("deletionTimestamp") is None]
+
+        if len(active_jobs) == 0:
+            break
+
+        time.sleep(wait_interval)
+
+    # Final verification that RayJob has been cleaned up for this specific run
+    final_jobs = rayjob_client.list(namespace=NAMESPACE, label_selector=f"dagster/run-id={run_id}")["items"]
+    active_final_jobs = [job for job in final_jobs if job.get("metadata", {}).get("deletionTimestamp") is None]
+
+    # The cleanup should have removed the RayJob created by this test
+    assert len(active_final_jobs) == 0, (
+        f"RayJob with run-id {run_id} should have been cleaned up, but found {len(active_final_jobs)} active jobs out of {len(final_jobs)} total jobs"
+    )
+
+    # Ensure no leftover jobs in case test failed
+    try:
+        jobs = rayjob_client.list(namespace=NAMESPACE)["items"]
+        for job in jobs:
+            rayjob_client.delete(job["metadata"]["name"], namespace=NAMESPACE)
+    except Exception:
+        pass  # Best effort cleanup
 
 
 @pytest.fixture(scope="session")
@@ -124,6 +252,7 @@ def interactive_rayjob_resource(
         ),
         redis_port=get_random_free_port(),
         lifecycle=Lifecycle(connect=False),
+        timeout=RAYJOB_TIMEOUT,
     )
 
 
@@ -143,7 +272,7 @@ def ensure_interactive_rayjob_correctness(
         target_port=10001,
         namespace=rayjob.namespace,
     ):
-        assert rayjob.client.get_status(rayjob.job_name, rayjob.namespace)["jobDeploymentStatus"] == "Waiting"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        assert rayjob.client.get_status(rayjob.name, rayjob.namespace)["jobDeploymentStatus"] == "Waiting"  # pyright: ignore[reportTypedDictNotRequiredAccess]
 
         # now we can access the head node
         # hack the _host attribute to point to the port-forwarded address
@@ -153,14 +282,14 @@ def ensure_interactive_rayjob_correctness(
 
         time.sleep(1)
 
-        job_status = rayjob.client.get_status(rayjob.job_name, rayjob.namespace).get("jobStatus")
+        job_status = rayjob.client.get_status(rayjob.name, rayjob.namespace).get("jobStatus")
         assert job_status == "RUNNING", job_status
 
         # make sure a @remote function runs inside the cluster
         # not in localhost
         assert rayjob.cluster_name in ray.get(get_hostname.remote())
 
-        rayjob_description = rayjob.client.get(rayjob.job_name, namespace=rayjob.namespace)
+        rayjob_description = rayjob.client.get(rayjob.name, namespace=rayjob.namespace)
         assert rayjob_description["metadata"]["labels"]["dagster/run-id"] == context.run_id
 
 

--- a/tests/kuberay/test_raycluster.py
+++ b/tests/kuberay/test_raycluster.py
@@ -270,7 +270,7 @@ def test_kuberay_cleanup_job(
 
 
 def test_ray_cluster_builder_debug():
-    kuberay_cluster = KubeRayCluster(enable_debug_post_mortem=True)
+    kuberay_cluster = KubeRayCluster(enable_debug_post_mortem=True, image="test")
     kuberay_cluster._cluster_name = "test-cluster"
     context = dg.build_init_resource_context()
 

--- a/tests/scripts/launch_dagster_run_with_kuberay_interactive_job.py
+++ b/tests/scripts/launch_dagster_run_with_kuberay_interactive_job.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Script for testing process interrupt cleanup behavior.
+This script creates a KubeRayInteractiveJob that will hang due to invalid image,
+allowing the parent test to interrupt it and verify cleanup behavior.
+"""
+
+import argparse
+import json
+import sys
+
+import dagster as dg
+
+from dagster_ray._base.resources import Lifecycle
+from dagster_ray.kuberay import KubeRayInteractiveJob
+from dagster_ray.kuberay.client.rayjob.client import RayJobClient
+from dagster_ray.kuberay.configs import RayClusterSpec
+from dagster_ray.kuberay.resources.rayjob import InteractiveRayJobConfig, InteractiveRayJobSpec
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Test script for process interrupt cleanup")
+    parser.add_argument("--config-file", required=True, help="Path to kubeconfig file")
+    parser.add_argument("--context", required=True, help="Kubernetes context name")
+    parser.add_argument("--image", required=True, help="Docker image name")
+    parser.add_argument("--cleanup", required=True, help="Cleanup behavior")
+    parser.add_argument("--redis-port", type=int, required=True, help="Redis port number")
+    parser.add_argument("--namespace", required=True, help="Kubernetes namespace")
+    parser.add_argument("--head-group-spec", required=True, help="Head group spec as JSON string")
+    parser.add_argument("--worker-group-specs", required=True, help="Worker group specs as JSON string")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Parse JSON arguments
+    try:
+        head_group_spec = json.loads(args.head_group_spec)
+        worker_group_specs = json.loads(args.worker_group_specs)
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JSON arguments: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Initialize the client and resource
+    client = RayJobClient(config_file=args.config_file, context=args.context)
+
+    interactive_rayjob = KubeRayInteractiveJob(
+        image=args.image,  # Invalid image that will cause hanging
+        client=client,
+        redis_port=args.redis_port,
+        ray_job=InteractiveRayJobConfig(
+            metadata={"namespace": args.namespace},
+            spec=InteractiveRayJobSpec(
+                ray_cluster_spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
+            ),
+        ),
+        lifecycle=Lifecycle(create=True, wait=True, connect=False, cleanup=args.cleanup),
+        timeout=300,  # Large timeout
+    )
+
+    @dg.asset
+    def hanging_asset(interactive_rayjob: KubeRayInteractiveJob) -> None:
+        return
+
+    res = dg.materialize(
+        assets=[hanging_asset],
+        resources={"interactive_rayjob": interactive_rayjob},
+        raise_on_error=False,
+    )
+
+    # we print the run id so the caller can use it to filter by RayJob `dagster/run-id` label in kubernetes
+    print(res.run_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -10,8 +10,6 @@ from dagster_ray import LocalRay, RayResource
 def test_runtime_env():
     import ray
 
-    ray.init
-
     @ray.remote
     def my_func():
         assert os.environ["FOO"] == "BAR"
@@ -32,8 +30,6 @@ def test_runtime_env():
 
 def test_debug_mode():
     import ray
-
-    ray.init
 
     @ray.remote
     def my_func():


### PR DESCRIPTION
- consolidate lifecycle management in `BaseRayResource`​
- add new `on_exception`​ cleanup policy 
    - it handles *only& exceptions during resource setup/teardown
    - it handles most `BaseException`​ (so `KeyboardInterrupt`​ is covered as well)
- `KubeRayInteractiveJob`​‘s default cleanup policy is now `on_exception`​. This ensures `RayJob` instances are not left in `Waiting` status if the Dagster step has been interrupted (cancelled by the user).