### PR TITLE
:bug: remove ignore_reinit_error from remote options

### DIFF
--- a/CHANDELOG.md
+++ b/CHANDELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - added `enable_legacy_debugger` configuration parameter to subclasses of `RayResource`
 
+## Fixes
+- removed `ignore_reinit_error` from `RayResource` init options: it's potentially dangerous, for example in case the user has accidentally connected to another Ray cluster (including local ray) before initializing the resource.
+
 ## 0.1.0
 
 ### Changed

--- a/dagster_ray/_base/resources.py
+++ b/dagster_ray/_base/resources.py
@@ -129,8 +129,6 @@ class BaseRayResource(ConfigurableResource, ABC):
                 k: v for k, v in init_options["runtime_env"]["env_vars"].items() if v is not None
             }
 
-        init_options["ignore_reinit_error"] = init_options.get("ignore_reinit_error", True)
-
         self.data_execution_options.apply()
 
         self._context = ray.init(


### PR DESCRIPTION
injecting `ignore_reinit_error` is (1) unnecessary and (2) silently problematic in certain scenarios 