### PR TITLE
:sparkles: implement cluster sharing for `KubeRayCluster`

### DIFF
--- a/CHANDELOG.md
+++ b/CHANDELOG.md
@@ -5,10 +5,35 @@ All notable user-facing changes to `dagster-ray` will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+This release introduces a new feature that is very useful in dev and staging environments: cluster sharing. Cluster sharing allows reusing existing `RayCluster` resources created by previous Dagster steps. This feature enables faster iteration speed and reduces costs. It's recommended for use in dev/staging environments. It's available with `KubeRayCluster`, which is now recommended over `KubeRayInteractiveJob` for non-production environments due to increased iteration speed. By default it selects existing Ray clusters based on the following labels:
+
+- `dagster/code-location`
+- `dagster/git-sha`
+- `dagster/resource-key`
+
+This feature is opt-in and can be enabled with:
+
+
+```py
+from dagster_ray.kuberay import KubeRayCluster, ClusterSharing
+
+ray_cluster = KubeRayCluster(cluster_sharing=ClusterSharing(enabled=True))
+```
+
+### Added
+- `KubeRayCluster.cluster_sharing` parameter that controls cluster sharing behavior.
+- `dagster_ray.kuberay.sensors.cleanup_expired_shared_clusters` sensor that cleans up expired clusters. A cluster is considered expired if it doesn't hold any alive locks placed by `dagster-ray`. The lock `ttl` defaults to 1 hour and can be configured in `KubeRayCluster.cluster_sharing`
+- system `dagster/step-key` tag/label is now placed on resources
+
+### Changed
+- [:bomb: breaking] - removed `cleanup_kuberay_clusters_op` and other associated definitions in favor of `dagster_ray.kuberay.sensors.cleanup_expired_kuberay_clusters` sensor that is more flexible
+
 ## 0.3.1
 
 ### Added
-- A new `failure_tolerance_timeout` configuration parameter for `KubeRayInteractiveJob` and `KubeRayCluster`. It can be set to a positive value to give the cluster some time to transition out of `failed` state (which can be transient in some scenarios) before raising an error.
+- `failure_tolerance_timeout` configuration parameter for `KubeRayInteractiveJob` and `KubeRayCluster`. It can be set to a positive value to give the cluster some time to transition out of `failed` state (which can be transient in some scenarios) before raising an error.
 
 ### Fixes
 - ensure both `.head.serviceIP` and `.head.serviceName` are set on the `RayCluster` while waiting for cluster readiness
@@ -37,8 +62,8 @@ This release includes massive docs improvements and drops support for Python 3.9
 - [:bomb: breaking] `RayJob` and `RayCluster` clients and resources Kubernetes init parameters have been renamed to `kube_config` and `kube_context`.
 
 ### Added
-- new `enable_legacy_debugger` configuration parameter to subclasses of `RayResource`
-- new `on_exception` option for `lifecycle.cleanup` policy. It's triggered during resource setup/cleanup (including `KeyboardInterrupt`), but not by user `@op`/`@asset` code.
+- `enable_legacy_debugger` configuration parameter to subclasses of `RayResource`
+- `on_exception` option for `lifecycle.cleanup` policy. It's triggered during resource setup/cleanup (including `KeyboardInterrupt`), but not by user `@op`/`@asset` code.
 - `KubeRayInteractiveJob` now respects `lifecycle.cleanup`. It defaults to `on_exception`. Users are advised to rely on built-in `RayJob` cleanup mechanisms, such as `ttlSecondsAfterFinished` and `deletionStrategy`.
 
 ### Fixes
@@ -53,5 +78,5 @@ This release includes massive docs improvements and drops support for Python 3.9
 - `dagster-ray` now populates Kubernetes labels with more values (including some useful Dagster Cloud values such as `git-sha`)
 
 ### Added
-- `KubeRayInteractiveJob` -- a new resource that utililizes the new `InteractiveMode` for `RayJob`. It can be used to connect to Ray in Client mode -- like `KubeRayCluster` -- but gives access to `RayJob` features, such as automatic cleanup (`ttlSecondsAfterFinished`), retries (`backoffLimit`) and timeouts (`activeDeadlineSeconds`).
+- `KubeRayInteractiveJob` -- a resource that utililizes the new `InteractiveMode` for `RayJob`. It can be used to connect to Ray in Client mode -- like `KubeRayCluster` -- but gives access to `RayJob` features, such as automatic cleanup (`ttlSecondsAfterFinished`), retries (`backoffLimit`) and timeouts (`activeDeadlineSeconds`).
 - `RayResource` setup lifecycle has been overhauled: resources now has an `actions` parameter with 3 configuration options: `create`, `wait` and `connect`. The user can disable them and run `.create()`, `.wait()` and `.connect()` manually if needed.

--- a/flake.nix
+++ b/flake.nix
@@ -32,10 +32,9 @@
           pkgs.glib
           pkgs.python310
         ];
-        UV_PYTHON = "${python}/bin/python";
+        # UV_PYTHON = "${python}/bin/python";
         shellHook = ''
-          uv venv --allow-existing
-          uv sync --frozen --all-extras --all-groups
+          uv python pin 3.10
         '';
       };
     };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ path = "src/dagster_ray/_version.py"
 addopts = "-vvv --capture=no --log-disable=faker"
 log_cli = true
 log_level = "INFO"
+pythonpath = ["."]  # adds current directory to PYTHONPATH so `tests` can be imported
 
 [tool.ruff]
 target-version = "py310"

--- a/src/dagster_ray/_base/cluster_sharing_lock.py
+++ b/src/dagster_ray/_base/cluster_sharing_lock.py
@@ -1,0 +1,46 @@
+import logging
+from collections.abc import Sequence
+from datetime import datetime, timedelta
+
+from pydantic import BaseModel, Field, ValidationError
+from typing_extensions import Self
+
+logger = logging.getLogger(__name__)
+
+
+class ClusterSharingLock(BaseModel):
+    run_id: str = Field(description="The ID of the Dagster run that placed the lock.")
+    step_key: str = Field(description="The key of the Dagster step that placed the lock.")
+    created_at: datetime = Field(description="The time at which the lock was created.")
+    ttl_seconds: float = Field(description="Time to live for the lock after which it's considered expired.")
+
+    @property
+    def identifier(self) -> str:
+        return f"{self.run_id}-{self.step_key}"
+
+    @property
+    def expired_at(self) -> datetime:
+        return self.created_at + timedelta(seconds=self.ttl_seconds)
+
+    @property
+    def is_expired(self) -> bool:
+        return self.created_at + timedelta(seconds=self.ttl_seconds) < datetime.now()
+
+    @classmethod
+    def parse_all_locks(cls, data: dict[str, str]) -> Sequence[Self]:
+        locks: list[Self] = []
+        if data:
+            for key, value in data.items():
+                if key.startswith("dagster/lock-"):
+                    try:
+                        lock = cls.model_validate_json(value)
+                        locks.append(lock)
+                    except ValidationError:
+                        logger.exception(
+                            f"Invalid cluster sharing lock: {key}={value}. Consider updating `dagster-ray`."
+                        )
+        return locks
+
+    @classmethod
+    def get_alive_locks(cls, locks: Sequence[Self]) -> Sequence[Self]:
+        return [lock for lock in locks if not lock.is_expired]

--- a/src/dagster_ray/_base/utils.py
+++ b/src/dagster_ray/_base/utils.py
@@ -13,6 +13,7 @@ def get_dagster_tags(
     Returns a dictionary with common Dagster tags.
     """
     assert context.dagster_run is not None
+    assert context.dagster_run.step_keys_to_execute is not None
 
     labels: dict[str, str] = {
         "dagster/deployment": DEFAULT_DEPLOYMENT_NAME,  # TODO: this should come from extra_tags,
@@ -33,5 +34,9 @@ def get_dagster_tags(
         labels.update(
             **context.run.dagster_execution_info,
         )
+
+    step_keys = context.dagster_run.step_keys_to_execute
+    if step_keys is not None and len(step_keys) == 1:
+        labels["dagster/step-key"] = step_keys[0]
 
     return labels

--- a/src/dagster_ray/configs.py
+++ b/src/dagster_ray/configs.py
@@ -7,6 +7,7 @@ import dagster as dg
 from pydantic import Field
 
 USER_DEFINED_RAY_KEY = "dagster-ray/config"
+DAGSTER_RAY_NAMESPACES_ENV_VAR = "DAGSTER_RAY_NAMESPACES"
 
 
 class Lifecycle(dg.Config):

--- a/src/dagster_ray/kuberay/__init__.py
+++ b/src/dagster_ray/kuberay/__init__.py
@@ -1,6 +1,6 @@
-from dagster_ray.kuberay.configs import RayClusterConfig, RayClusterSpec, RayJobConfig, RayJobSpec
-from dagster_ray.kuberay.jobs import cleanup_kuberay_clusters, delete_kuberay_clusters
-from dagster_ray.kuberay.ops import cleanup_kuberay_clusters_op, delete_kuberay_clusters_op
+from dagster_ray.kuberay.configs import ClusterSharing, RayClusterConfig, RayClusterSpec, RayJobConfig, RayJobSpec
+from dagster_ray.kuberay.jobs import delete_kuberay_clusters
+from dagster_ray.kuberay.ops import delete_kuberay_clusters_op
 from dagster_ray.kuberay.pipes import PipesKubeRayJobClient
 from dagster_ray.kuberay.resources import (
     KubeRayCluster,
@@ -8,21 +8,20 @@ from dagster_ray.kuberay.resources import (
     KubeRayInteractiveJob,
     KubeRayJobClientResource,
 )
-from dagster_ray.kuberay.schedules import cleanup_kuberay_clusters_daily
+from dagster_ray.kuberay.sensors import cleanup_expired_kuberay_clusters
 
 __all__ = [
     "KubeRayCluster",
     "RayClusterConfig",
     "KubeRayClusterClientResource",
     "PipesKubeRayJobClient",
-    "cleanup_kuberay_clusters",
     "delete_kuberay_clusters",
-    "cleanup_kuberay_clusters_op",
     "delete_kuberay_clusters_op",
-    "cleanup_kuberay_clusters_daily",
+    "cleanup_expired_kuberay_clusters",
     "RayClusterSpec",
     "RayJobConfig",
     "RayJobSpec",
     "KubeRayInteractiveJob",
     "KubeRayJobClientResource",
+    "ClusterSharing",
 ]

--- a/src/dagster_ray/kuberay/client/rayjob/client.py
+++ b/src/dagster_ray/kuberay/client/rayjob/client.py
@@ -48,10 +48,13 @@ class RayJobClient(BaseKubeRayClient[RayJobStatus]):
         # this call must happen BEFORE creating K8s apis
         load_kubeconfig(config_file=kube_config, context=kube_context)
 
-        self.config_file = kube_config
-        self.context = kube_context
+        self.kube_config = kube_config
+        self.kube_context = kube_context
 
         super().__init__(group=GROUP, version=VERSION, kind=KIND, plural=PLURAL, api_client=api_client)
+
+    def load_kubeconfig(self):
+        load_kubeconfig(context=self.kube_context, config_file=self.kube_config)
 
     def get_ray_cluster_name(self, name: str, namespace: str, timeout: float, poll_interval: float = 1.0) -> str:
         return self.get_status(name, namespace, timeout=timeout, poll_interval=poll_interval)["rayClusterName"]
@@ -64,7 +67,7 @@ class RayJobClient(BaseKubeRayClient[RayJobStatus]):
 
     @property
     def ray_cluster_client(self) -> RayClusterClient:
-        return RayClusterClient(kube_config=self.config_file, kube_context=self.context)
+        return RayClusterClient(kube_config=self.kube_config, kube_context=self.kube_context)
 
     def wait_until_ready(
         self,

--- a/src/dagster_ray/kuberay/jobs.py
+++ b/src/dagster_ray/kuberay/jobs.py
@@ -1,16 +1,8 @@
 import dagster as dg
 
-from dagster_ray.kuberay.ops import cleanup_kuberay_clusters_op, delete_kuberay_clusters_op
+from dagster_ray.kuberay.ops import delete_kuberay_clusters_op
 
 
-@dg.job(description="Deletes RayCluster resources from Kubernetes", name="delete_kuberay_rayclusters")
+@dg.job(description="Deletes KubeRay `RayCluster` resources", name="delete_kuberay_clusters")
 def delete_kuberay_clusters():
     delete_kuberay_clusters_op()
-
-
-@dg.job(
-    description="Deletes RayCluster resources which do not correspond to any active Dagster Runs in this deployment from Kubernetes",
-    name="cleanup_kuberay_rayclusters",
-)
-def cleanup_kuberay_clusters():
-    cleanup_kuberay_clusters_op()

--- a/src/dagster_ray/kuberay/resources/raycluster.py
+++ b/src/dagster_ray/kuberay/resources/raycluster.py
@@ -1,27 +1,31 @@
+from collections.abc import Sequence
+from datetime import datetime
+from typing import cast
+
 import dagster as dg
 from pydantic import Field, PrivateAttr
 from typing_extensions import override
 
+from dagster_ray._base.cluster_sharing_lock import ClusterSharingLock
 from dagster_ray._base.resources import RayResource
 from dagster_ray.configs import Lifecycle
 from dagster_ray.kuberay.client import RayClusterClient
-from dagster_ray.kuberay.client.base import load_kubeconfig
-from dagster_ray.kuberay.configs import RayClusterConfig
+from dagster_ray.kuberay.configs import ClusterSharing, RayClusterConfig
 from dagster_ray.kuberay.resources.base import BaseKubeRayResourceConfig
 from dagster_ray.kuberay.utils import normalize_k8s_label_values
 from dagster_ray.types import AnyDagsterContext
 
 
 class KubeRayClusterClientResource(dg.ConfigurableResource[RayClusterClient]):
-    """This configurable resource provides a `dagster_ray.kuberay.client.RayClusterClient`."""
+    """This configurable resource provides a [dagster_ray.kuberay.client.RayClusterClient][]."""
 
     kube_context: str | None = None
     kube_config: str | None = None
 
     def create_resource(self, context: dg.InitResourceContext) -> RayClusterClient:
-        load_kubeconfig(context=self.kube_context, config_file=self.kube_config)
-
-        return RayClusterClient(kube_context=self.kube_context, kube_config=self.kube_config)
+        client = RayClusterClient(kube_context=self.kube_context, kube_config=self.kube_config)
+        client.load_kubeconfig()
+        return client
 
 
 class KubeRayCluster(BaseKubeRayResourceConfig, RayResource):
@@ -39,6 +43,11 @@ class KubeRayCluster(BaseKubeRayResourceConfig, RayResource):
 
     lifecycle: Lifecycle = Field(
         default_factory=lambda: Lifecycle(cleanup="always"), description="Actions to perform during resource setup."
+    )
+
+    cluster_sharing: ClusterSharing = Field(
+        default_factory=ClusterSharing,
+        description="Configuration for sharing the `RayCluster` across Dagster steps. Existing clusters matching this configuration will be reused without recreating them. A `dagster/sharing=true` label will be applied to the `RayCluster`, and a `dagster/lock-<run-id>-<step-id>=<lock>` annotation will be placed on the `RayCluster` to mark it as being used by this step. Cleanup will only proceed if the `RayCluster` is not being used by any other steps, therefore cluster sharing should be used in conjunction with [dagster_ray.kuberay.sensors.cleanup_expired_kuberay_clusters][] sensor.",
     )
 
     ray_cluster: RayClusterConfig = Field(
@@ -84,12 +93,56 @@ class KubeRayCluster(BaseKubeRayResourceConfig, RayResource):
     def get_dagster_tags(self, context: AnyDagsterContext) -> dict[str, str]:
         tags = super().get_dagster_tags(context=context)
         tags.update({"dagster/deployment": self.deployment_name})
+        if self.cluster_sharing.enabled:
+            tags.update({"dagster/cluster-sharing": "true"})
         return tags
+
+    def get_k8s_labels(self, context: AnyDagsterContext) -> dict[str, str]:
+        return normalize_k8s_label_values(self.get_dagster_tags(context))
+
+    def get_image(self, context: AnyDagsterContext) -> str | None:
+        assert context.dagster_run is not None
+        return self.image or context.dagster_run.tags.get("dagster/image")
 
     @override
     def create(self, context: AnyDagsterContext):
         assert context.log is not None
         assert context.dagster_run is not None
+
+        labels = self.get_k8s_labels(context)
+        annotations: dict[str, str] = {}
+
+        if self.cluster_sharing.enabled:
+            label_selector = self.get_sharing_label_selector(context)
+            context.log.info(
+                f"RayCluster sharing is enabled. Looking for clusters matching label selector: {label_selector}"
+            )
+            # check whether a cluster matching the sharing config already exists
+            matching_clusters = self.client.list(
+                label_selector=label_selector,
+                namespace=self.namespace,
+            )
+            if matching_clusters and (clusters := matching_clusters.get("items", [])):
+                cluster_name = clusters[0]["metadata"]["name"]
+                context.log.info(
+                    f"Found {len(matching_clusters)} clusters matching the label selector. Using the first one: {cluster_name}"
+                )
+                self._name = cluster_name
+
+                # place a lock on the cluster
+
+                self.client.update(
+                    name=cluster_name,
+                    namespace=self.namespace,
+                    body={"metadata": {"annotations": self.get_sharing_lock_annotations(context)}},
+                )
+
+                return
+            else:
+                context.log.info("No matching clusters found. Creating a new one.")
+
+                # mark the cluster as being used by this step
+                annotations.update(self.get_sharing_lock_annotations(context))
 
         self._name = self.ray_cluster.metadata.get("name") or self._get_step_name(context)
 
@@ -100,8 +153,9 @@ class KubeRayCluster(BaseKubeRayResourceConfig, RayResource):
         ):
             k8s_manifest = self.ray_cluster.to_k8s(
                 context,
-                image=(self.image or context.dagster_run.tags.get("dagster/image")),
-                labels=normalize_k8s_label_values(self.get_dagster_tags(context)),
+                image=self.get_image(context),
+                labels=labels,
+                annotations=annotations,
                 env_vars=self.get_env_vars_to_inject(),
             )
 
@@ -139,3 +193,78 @@ class KubeRayCluster(BaseKubeRayResourceConfig, RayResource):
     @override
     def delete(self, context: AnyDagsterContext):
         self.client.delete(self.name, namespace=self.namespace)
+
+    @override
+    def cleanup(self, context: AnyDagsterContext, exception: BaseException | None):
+        assert context.log is not None
+        assert context.run_id is not None
+        # we don't want to perform cleanup if:
+        # - cluster sharing is enabled
+        # - cluster has at least one lock that hasn't expired yet
+        if self.cluster_sharing.enabled:
+            # get sharing locks created by this or another Dagster step
+            alive_locks = self.get_cluster_sharing_alive_locks(context)
+            if len(alive_locks) > 0:
+                context.log.info(
+                    f"Skipping cluster cleanup due to active cluster sharing locks: {', '.join([lock.identifier for lock in alive_locks])}"
+                )
+                return
+
+        super().cleanup(context, exception)
+
+    def get_sharing_label_selector(self, context: AnyDagsterContext) -> str:
+        """This method combines user-provided label selectors from the sharing config with default (dagster-generated) labels to match on.
+
+        User-provided labels take priority. This method can be overridden to customize cluster sharing behavior.
+        """
+        labels = self.get_k8s_labels(context)
+
+        dagster_match_labels: dict[str, str] = {}
+
+        if self.cluster_sharing:
+            if self.cluster_sharing.match_dagster_labels.cluster_sharing:
+                dagster_match_labels["dagster/cluster-sharing"] = "true"
+            if self.cluster_sharing.match_dagster_labels.code_location and (
+                code_location := labels.get("dagster/code-location")
+            ):
+                dagster_match_labels["dagster/code-location"] = code_location
+            if self.cluster_sharing.match_dagster_labels.resource_key:
+                dagster_match_labels["dagster/resource-key"] = labels["dagster/resource-key"]
+            if self.cluster_sharing.match_dagster_labels.run_id:
+                dagster_match_labels["dagster/run-id"] = labels["dagster/run-id"]
+            if self.cluster_sharing.match_dagster_labels.commit_sha and (
+                commit_sha := labels.get("dagster/commit-sha")
+            ):
+                dagster_match_labels["dagster/commit-sha"] = commit_sha
+
+        combined_match_labels = {
+            **dagster_match_labels,
+            **(self.cluster_sharing.match_labels or {}),
+        }
+
+        return ",".join([f"{key}={value}" for key, value in combined_match_labels.items()])
+
+    def get_sharing_lock_annotations(self, context: AnyDagsterContext) -> dict[str, str]:
+        assert context.run_id is not None
+        assert context.dagster_run is not None
+
+        annotations = {}
+        if context.dagster_run.step_keys_to_execute:
+            for step_key in context.dagster_run.step_keys_to_execute:
+                lock = ClusterSharingLock(
+                    run_id=context.run_id,
+                    step_key=step_key,
+                    ttl_seconds=self.cluster_sharing.ttl_seconds,
+                    created_at=datetime.now(),
+                )
+                annotations[f"dagster/lock-{lock.identifier}"] = lock.model_dump_json()
+        return annotations
+
+    def get_cluster_sharing_alive_locks(self, context: AnyDagsterContext) -> Sequence[ClusterSharingLock]:
+        locks = ClusterSharingLock.parse_all_locks(
+            cast(
+                dict[str, str],
+                self.client.get(name=self.name, namespace=self.namespace).get("metadata", {}).get("annotations", {}),
+            )
+        )
+        return ClusterSharingLock.get_alive_locks(locks)

--- a/src/dagster_ray/kuberay/resources/rayjob.py
+++ b/src/dagster_ray/kuberay/resources/rayjob.py
@@ -7,7 +7,6 @@ from typing_extensions import override
 from dagster_ray._base.resources import RayResource
 from dagster_ray.configs import Lifecycle
 from dagster_ray.kuberay.client import RayJobClient
-from dagster_ray.kuberay.client.base import load_kubeconfig
 from dagster_ray.kuberay.configs import RayJobConfig, RayJobSpec
 from dagster_ray.kuberay.resources.base import BaseKubeRayResourceConfig
 from dagster_ray.kuberay.utils import normalize_k8s_label_values
@@ -21,14 +20,15 @@ if TYPE_CHECKING:
 
 
 class KubeRayJobClientResource(dg.ConfigurableResource[RayJobClient]):
-    """This configurable resource provides a `dagster_ray.kuberay.client.RayJobClient`."""
+    """This configurable resource provides a [dagster_ray.kuberay.client.RayJobClient][]."""
 
     kube_context: str | None = None
     kube_config: str | None = None
 
     def create_resource(self, context: dg.InitResourceContext):
-        load_kubeconfig(context=self.kube_context, config_file=self.kube_config)
-        return RayJobClient(kube_context=self.kube_context, kube_config=self.kube_config)
+        client = RayJobClient(kube_context=self.kube_context, kube_config=self.kube_config)
+        client.load_kubeconfig()
+        return client
 
 
 class InteractiveRayJobSpec(RayJobSpec):

--- a/src/dagster_ray/kuberay/schedules.py
+++ b/src/dagster_ray/kuberay/schedules.py
@@ -1,9 +1,0 @@
-import dagster as dg
-
-from dagster_ray.kuberay.jobs import cleanup_kuberay_clusters
-
-cleanup_kuberay_clusters_daily = dg.ScheduleDefinition(
-    job=cleanup_kuberay_clusters,
-    cron_schedule="0 0 * * *",
-    name="cleanup_kuberay_clusters_schedule_daily",
-)

--- a/src/dagster_ray/kuberay/sensors.py
+++ b/src/dagster_ray/kuberay/sensors.py
@@ -1,0 +1,57 @@
+import os
+from collections.abc import Generator
+from typing import cast
+
+import dagster as dg
+
+from dagster_ray._base.cluster_sharing_lock import ClusterSharingLock
+from dagster_ray.configs import DAGSTER_RAY_NAMESPACES_ENV_VAR
+from dagster_ray.kuberay.client.raycluster.client import RayClusterClient
+from dagster_ray.kuberay.jobs import delete_kuberay_clusters
+from dagster_ray.kuberay.ops import DeleteKubeRayClustersConfig, RayClusterRef
+
+
+@dg.sensor(job=delete_kuberay_clusters, default_status=dg.DefaultSensorStatus.RUNNING, minimum_interval_seconds=60)
+def cleanup_expired_kuberay_clusters(
+    context: dg.SensorEvaluationContext,
+    raycluster_client: dg.ResourceParam[RayClusterClient],
+) -> Generator[dg.RunRequest | dg.SkipReason, None, None]:
+    f"""A Dagster sensor that monitors shared `RayCluster` resources created by the current code location and submits jobs to delete clusters that have expired.
+
+    Selects clusters based on the following labels:
+        - `dagster/cluster-sharing=true`
+        - `dagster/code-location=<current-code-location>`
+
+    By default it monitors the `ray` namespace. This can be configured by setting `{DAGSTER_RAY_NAMESPACES_ENV_VAR}` (accepts a comma-separated list of namespaces)."""
+    assert context.code_location_origin is not None
+
+    found_any = False
+    namespaces = os.environ.get(DAGSTER_RAY_NAMESPACES_ENV_VAR, "ray").split(",")
+    for namespace in namespaces:
+        cluster_names = []
+        for cluster in raycluster_client.list(
+            namespace=namespace,
+            label_selector=f"dagster/code-location={context.code_location_origin.location_name},dagster/cluster-sharing=true",
+        ).get("items", []):
+            locks = ClusterSharingLock.parse_all_locks(
+                cast(dict[str, str], cluster.get("metadata", {}).get("annotations", {}))
+            )
+            alive_locks = ClusterSharingLock.get_alive_locks(locks)
+            if not alive_locks:
+                cluster_names.append(cluster["metadata"]["name"])
+
+        if len(cluster_names) > 0:
+            found_any = True
+            yield dg.RunRequest(
+                run_config=dg.RunConfig(
+                    ops={
+                        "delete_kuberay_clusters": DeleteKubeRayClustersConfig(
+                            namespace=namespace,
+                            clusters=[RayClusterRef(name=name) for name in cluster_names],
+                        )
+                    }
+                )
+            )
+
+    if not found_any:
+        yield dg.SkipReason(f"No expired RayClusters found in namespaces: {namespaces}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,15 @@
 import logging
+import os
+import sys
 from collections.abc import Iterator
 
 import dagster as dg
 import pytest
 from _pytest.tmpdir import TempPathFactory
+from dagster._core.types.loadable_target_origin import LoadableTargetOrigin
+
+# this import only works under `pytest` because of pytest.ini_options.pythonpath setting
+from tests.utils import InProcessCodeLocationOrigin  # pyright:ignore[reportAttributeAccessIssue]
 
 logging.getLogger("alembic").setLevel(logging.WARNING)
 
@@ -24,3 +30,16 @@ def local_ray_address() -> Iterator[str]:
     yield "auto"
 
     context.disconnect()
+
+
+@pytest.fixture
+def code_location_origin() -> InProcessCodeLocationOrigin:
+    return InProcessCodeLocationOrigin(
+        loadable_target_origin=LoadableTargetOrigin(
+            executable_path=sys.executable,
+            module_name=("dagster_ray.tests.kuberay.conftest"),
+            working_directory=os.getcwd(),
+            attribute="lmao",
+        ),
+        location_name="test_location",
+    )

--- a/tests/kuberay/test_raycluster.py
+++ b/tests/kuberay/test_raycluster.py
@@ -1,4 +1,6 @@
 import socket
+import time
+from datetime import datetime, timedelta
 from typing import Any, cast
 
 import dagster as dg
@@ -7,23 +9,59 @@ import ray  # noqa: TID253
 from pytest_kubernetes.providers import AClusterManager
 
 from dagster_ray import Lifecycle, RayResource
-from dagster_ray.kuberay import KubeRayCluster, KubeRayClusterClientResource, RayClusterConfig, cleanup_kuberay_clusters
+from dagster_ray._base.cluster_sharing_lock import ClusterSharingLock
+from dagster_ray.kuberay import (
+    KubeRayCluster,
+    KubeRayClusterClientResource,
+    RayClusterConfig,
+    cleanup_expired_kuberay_clusters,
+)
 from dagster_ray.kuberay.client import RayClusterClient
-from dagster_ray.kuberay.configs import RayClusterSpec
-from dagster_ray.kuberay.ops import CleanupKuberayClustersConfig
+from dagster_ray.kuberay.configs import ClusterSharing, RayClusterSpec
+from dagster_ray.kuberay.jobs import delete_kuberay_clusters
+from dagster_ray.kuberay.ops import DeleteKubeRayClustersConfig, RayClusterRef
 from tests.kuberay.conftest import KUBERNETES_CONTEXT
 from tests.kuberay.utils import NAMESPACE, get_random_free_port
+from tests.utils import CodeLocationOrigin  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def delete_shared_rayclusters(raycluster_client: RayClusterClient | KubeRayClusterClientResource):
+    raycluster_client = (
+        raycluster_client
+        if isinstance(raycluster_client, RayClusterClient)
+        else RayClusterClient(kube_config=raycluster_client.kube_config, kube_context=raycluster_client.kube_context)
+    )
+    clusters = raycluster_client.list(namespace=NAMESPACE).get("items", [])
+    for cluster in clusters:
+        if cluster["metadata"].get("labels", {}).get("dagster/cluster-sharing") == "true":
+            raycluster_client.delete(name=cluster["metadata"]["name"], namespace=cluster["metadata"]["namespace"])
+
+
+@pytest.fixture(scope="session")
+def raycluster_client_resource(k8s_with_kuberay: AClusterManager):
+    return KubeRayClusterClientResource(kube_config=str(k8s_with_kuberay.kubeconfig), kube_context=KUBERNETES_CONTEXT)
 
 
 @pytest.fixture(scope="session")
 def raycluster_client(k8s_with_kuberay: AClusterManager):
-    return KubeRayClusterClientResource(kube_config=str(k8s_with_kuberay.kubeconfig), kube_context=KUBERNETES_CONTEXT)
+    return RayClusterClient(kube_config=str(k8s_with_kuberay.kubeconfig), kube_context=KUBERNETES_CONTEXT)
+
+
+@pytest.fixture
+def shared_clusters_cleanup(raycluster_client: RayClusterClient):
+    delete_shared_rayclusters(raycluster_client)
+    yield
+    delete_shared_rayclusters(raycluster_client)
+
+
+def test_instantiate_defaults():
+    _ = KubeRayCluster()
 
 
 @pytest.fixture(scope="session")
 def ray_cluster_resource(
     k8s_with_kuberay: AClusterManager,
-    raycluster_client: KubeRayClusterClientResource,
+    raycluster_client_resource: KubeRayClusterClientResource,
     dagster_ray_image: str,
     head_group_spec: dict[str, Any],
     worker_group_specs: list[dict[str, Any]],
@@ -35,7 +73,7 @@ def ray_cluster_resource(
         # have have to first run port-forwarding with minikube
         # we can only init ray after that
         lifecycle=Lifecycle(connect=False),
-        client=raycluster_client,
+        client=raycluster_client_resource,
         ray_cluster=RayClusterConfig(
             metadata={"namespace": NAMESPACE},
             spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
@@ -50,7 +88,7 @@ def ray_cluster_resource_skip_cleanup(
     dagster_ray_image: str,
     head_group_spec: dict[str, Any],
     worker_group_specs: list[dict[str, Any]],
-    raycluster_client: KubeRayClusterClientResource,
+    raycluster_client_resource: KubeRayClusterClientResource,
 ) -> KubeRayCluster:
     redis_port = get_random_free_port()
 
@@ -62,7 +100,7 @@ def ray_cluster_resource_skip_cleanup(
             connect=False,
             cleanup="never",
         ),
-        client=raycluster_client,
+        client=raycluster_client_resource,
         ray_cluster=RayClusterConfig(
             metadata={"namespace": NAMESPACE},
             spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
@@ -77,7 +115,7 @@ def ray_cluster_resource_skip_create(
     dagster_ray_image: str,
     head_group_spec: dict[str, Any],
     worker_group_specs: list[dict[str, Any]],
-    raycluster_client: KubeRayClusterClientResource,
+    raycluster_client_resource: KubeRayClusterClientResource,
 ) -> KubeRayCluster:
     redis_port = get_random_free_port()
 
@@ -86,7 +124,7 @@ def ray_cluster_resource_skip_create(
         # have have to first run port-forwarding with minikube
         # we can only init ray after that
         lifecycle=Lifecycle(create=False),
-        client=raycluster_client,
+        client=raycluster_client_resource,
         ray_cluster=RayClusterConfig(
             metadata={"namespace": NAMESPACE},
             spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
@@ -101,7 +139,7 @@ def ray_cluster_resource_skip_wait(
     dagster_ray_image: str,
     head_group_spec: dict[str, Any],
     worker_group_specs: list[dict[str, Any]],
-    raycluster_client: KubeRayClusterClientResource,
+    raycluster_client_resource: KubeRayClusterClientResource,
 ) -> KubeRayCluster:
     redis_port = get_random_free_port()
 
@@ -110,7 +148,7 @@ def ray_cluster_resource_skip_wait(
         # have have to first run port-forwarding with minikube
         # we can only init ray after that
         lifecycle=Lifecycle(wait=False),
-        client=raycluster_client,
+        client=raycluster_client_resource,
         ray_cluster=RayClusterConfig(
             metadata={"namespace": NAMESPACE},
             spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
@@ -152,6 +190,7 @@ def ensure_kuberay_cluster_correctness(
 def test_kuberay_cluster_resource(
     ray_cluster_resource: KubeRayCluster,
     k8s_with_kuberay: AClusterManager,
+    raycluster_client: RayClusterClient,
 ):
     @dg.asset
     # testing RayResource type annotation too!
@@ -172,13 +211,11 @@ def test_kuberay_cluster_resource(
         resources={"ray_cluster": ray_cluster_resource},
     )
 
-    kuberay_client = RayClusterClient(kube_config=str(k8s_with_kuberay.kubeconfig))
-
     # make sure the RayCluster is cleaned up
 
     assert (
         len(
-            kuberay_client.list(
+            raycluster_client.list(
                 namespace=ray_cluster_resource.namespace, label_selector=f"dagster/run-id={result.run_id}"
             )["items"]
         )
@@ -233,49 +270,6 @@ def test_kuberay_cluster_resource_skip_wait(
     )
 
 
-def test_kuberay_cleanup_job(
-    ray_cluster_resource_skip_cleanup: KubeRayCluster,
-    k8s_with_kuberay: AClusterManager,
-):
-    @dg.asset
-    def my_asset(ray_cluster: RayResource) -> None:
-        assert isinstance(ray_cluster, KubeRayCluster)
-
-    result = dg.materialize_to_memory(
-        [my_asset],
-        resources={"ray_cluster": ray_cluster_resource_skip_cleanup},
-    )
-
-    raycluster_client = RayClusterClient(kube_config=str(k8s_with_kuberay.kubeconfig), kube_context=KUBERNETES_CONTEXT)
-
-    assert (
-        len(
-            raycluster_client.list(
-                namespace=ray_cluster_resource_skip_cleanup.namespace,
-                label_selector=f"dagster/run-id={result.run_id}",
-            )["items"]
-        )
-        > 0
-    )
-
-    cleanup_kuberay_clusters.execute_in_process(
-        resources={
-            "kuberay_client": KubeRayClusterClientResource(kube_config=str(k8s_with_kuberay.kubeconfig)),
-        },
-        run_config=dg.RunConfig(
-            ops={
-                "cleanup_kuberay_clusters": CleanupKuberayClustersConfig(
-                    namespace=ray_cluster_resource_skip_cleanup.namespace,
-                )
-            }
-        ),
-    )
-
-    assert not raycluster_client.list(
-        namespace=ray_cluster_resource_skip_cleanup.namespace, label_selector=f"dagster/run-id={result.run_id}"
-    )["items"]
-
-
 def test_ray_cluster_builder_debug():
     kuberay_cluster = KubeRayCluster(enable_debug_post_mortem=True, image="test")
     kuberay_cluster._cluster_name = "test-cluster"
@@ -307,3 +301,262 @@ def test_ray_cluster_builder_debug():
     for group_spec in [ray_cluster_config["spec"]["headGroupSpec"], *ray_cluster_config["spec"]["workerGroupSpecs"]]:
         for container in group_spec["template"]["spec"]["containers"]:
             assert {"name": "RAY_ENABLE_RECORD_ACTOR_TASK_LOGGING", "value": "1"} in container["env"], container
+
+
+def test_cleanup_expired_kuberay_clusters_sensor_skip(
+    code_location_origin: CodeLocationOrigin,
+    dagster_instance: dg.DagsterInstance,
+    raycluster_client: RayClusterClient,
+    shared_clusters_cleanup,
+):
+    # run the sensor - it shouldn't request any runs
+    context = dg.build_sensor_context(instance=dagster_instance)
+    context._code_location_origin = code_location_origin
+    for item in cleanup_expired_kuberay_clusters(  # pyright: ignore[reportGeneralTypeIssues,reportOptionalIterable]
+        context, raycluster_client=raycluster_client
+    ):
+        assert isinstance(item, dg.SkipReason)
+
+
+def test_cleanup_expired_kuberay_clusters_sensor_request(
+    k8s_with_kuberay: AClusterManager,
+    dagster_ray_image: str,
+    code_location_origin: CodeLocationOrigin,
+    dagster_instance: dg.DagsterInstance,
+    raycluster_client_resource: KubeRayClusterClientResource,
+    raycluster_client: RayClusterClient,
+    head_group_spec: dict[str, Any],
+    worker_group_specs: list[dict[str, Any]],
+    shared_clusters_cleanup,
+):
+    # run the sensor - it shouldn't request any runs
+    context = dg.build_sensor_context(instance=dagster_instance)
+    context._code_location_origin = code_location_origin
+    for item in cleanup_expired_kuberay_clusters(  # pyright: ignore[reportGeneralTypeIssues,reportOptionalIterable]
+        context, raycluster_client=raycluster_client
+    ):
+        assert isinstance(item, dg.SkipReason)
+
+    ray_cluster = KubeRayCluster(
+        image=dagster_ray_image,
+        # have have to first run port-forwarding with minikube
+        # we can only init ray after that
+        lifecycle=Lifecycle(wait=False),
+        client=raycluster_client_resource,
+        ray_cluster=RayClusterConfig(
+            # dagster/code-location should be added manually since there is no (normal) way to set the code location name for `dg.materialize`
+            metadata={"namespace": NAMESPACE, "labels": {"dagster/code-location": "test_location"}},
+            spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
+        ),
+        redis_port=get_random_free_port(),
+        cluster_sharing=ClusterSharing(enabled=True, ttl_seconds=10),
+    )
+
+    @dg.asset
+    def my_asset(context: dg.AssetExecutionContext, ray_cluster: RayResource):
+        return "Hello, World!"
+
+    res = dg.materialize(assets=[my_asset], resources={"ray_cluster": ray_cluster})
+    clusters = raycluster_client.list(
+        namespace=ray_cluster.namespace,
+        label_selector=f"dagster/run-id={res.run_id}",
+    )["items"]
+
+    # cluster should not be cleaned up yet since it has a TTL of 10 seconds
+    assert len(clusters) == 1
+    cluster = clusters[0]
+
+    assert cluster["metadata"]["labels"].get("dagster/cluster-sharing") == "true"
+    assert cluster["metadata"]["labels"].get("dagster/code-location") == "test_location"
+
+    locks = ClusterSharingLock.parse_all_locks(cluster["metadata"]["annotations"])
+    assert len(locks) == 1
+    lock = locks[0]
+    assert lock.ttl_seconds == 10.0
+    assert not lock.is_expired
+
+    # wait until the lock expires
+    time.sleep((lock.expired_at - datetime.now()).total_seconds() + 0.5)
+
+    assert lock.is_expired
+
+    # run the sensor - it should request a run
+    context = dg.build_sensor_context(instance=dagster_instance)
+    context._code_location_origin = code_location_origin
+    for item in cleanup_expired_kuberay_clusters(  # pyright: ignore[reportGeneralTypeIssues,reportOptionalIterable]
+        context, raycluster_client=raycluster_client
+    ):
+        assert isinstance(item, dg.RunRequest)
+        assert (
+            item.run_config["ops"]["delete_kuberay_clusters"]["config"]["clusters"][0]["name"]
+            == cluster["metadata"]["name"]
+        )
+
+
+def test_cluster_sharing(
+    k8s_with_kuberay: AClusterManager,
+    dagster_ray_image: str,
+    raycluster_client_resource: KubeRayClusterClientResource,
+    raycluster_client: RayClusterClient,
+    head_group_spec: dict[str, Any],
+    worker_group_specs: list[dict[str, Any]],
+    dagster_instance: dg.DagsterInstance,
+    code_location_origin: CodeLocationOrigin,
+    shared_clusters_cleanup,
+):
+    ray_cluster = KubeRayCluster(
+        image=dagster_ray_image,
+        # have have to first run port-forwarding with minikube
+        # we can only init ray after that
+        lifecycle=Lifecycle(wait=False),
+        client=raycluster_client_resource,
+        ray_cluster=RayClusterConfig(
+            metadata={"namespace": NAMESPACE},
+            spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
+        ),
+        redis_port=get_random_free_port(),
+        cluster_sharing=ClusterSharing(enabled=True),
+    )
+
+    @dg.asset
+    def my_asset(context: dg.AssetExecutionContext, ray_cluster: RayResource):
+        annotations = ray_cluster.get_sharing_lock_annotations(context)
+        assert len(list(filter(lambda x: x.startswith(f"dagster/lock-{context.run_id}"), annotations.keys()))) == 1
+        return "Hello, World!"
+
+    res = dg.materialize(assets=[my_asset], resources={"ray_cluster": ray_cluster})
+
+    # with cluster sharing enabled the cluster should not be cleaned up
+    clusters = raycluster_client.list(
+        namespace=ray_cluster.namespace,
+        label_selector=f"dagster/run-id={res.run_id}",
+    )["items"]
+    assert len(clusters) == 1
+
+    cluster = clusters[0]
+
+    assert cluster["metadata"]["labels"].get("dagster/cluster-sharing") == "true"
+
+    locks = ClusterSharingLock.parse_all_locks(cluster["metadata"]["annotations"])
+    assert len(locks) == 1
+    lock = locks[0]
+    assert lock.run_id == res.run_id
+    assert lock.created_at + timedelta(seconds=cast(float, lock.ttl_seconds)) > datetime.now()
+    assert not lock.is_expired
+
+    # run the sensor - it shouldn't request any runs
+
+    context = dg.build_sensor_context(instance=dagster_instance)
+    context._code_location_origin = code_location_origin
+
+    for item in cleanup_expired_kuberay_clusters(context, raycluster_client=raycluster_client):  # pyright: ignore[reportGeneralTypeIssues,reportOptionalIterable]
+        assert isinstance(item, dg.SkipReason)
+
+    # run the asset again, it shouldn't create a new RayCluster this time
+
+    res_2 = dg.materialize(assets=[my_asset], resources={"ray_cluster": ray_cluster})
+
+    # the old cluster should still be around and it should contain the new run in one of the lock annotations
+    updated_cluster = raycluster_client.list(
+        namespace=ray_cluster.namespace,
+        label_selector=f"dagster/run-id={res.run_id}",
+    )["items"][0]
+
+    assert cluster["metadata"]["labels"] == updated_cluster["metadata"]["labels"]
+    locks = ClusterSharingLock.parse_all_locks(updated_cluster["metadata"]["annotations"])
+    assert len(locks) == 2
+    assert locks[0].run_id != locks[1].run_id
+
+    # the new run should not have any clusters associated with it
+    assert (
+        len(
+            raycluster_client.list(
+                namespace=ray_cluster.namespace,
+                label_selector=f"dagster/run-id={res_2.run_id}",
+            )["items"]
+        )
+        == 0
+    )
+
+
+def test_cluster_sharing_cleanup_expired(
+    dagster_ray_image: str,
+    raycluster_client_resource: KubeRayClusterClientResource,
+    raycluster_client: RayClusterClient,
+    head_group_spec: dict[str, Any],
+    worker_group_specs: list[dict[str, Any]],
+    shared_clusters_cleanup,
+):
+    ray_cluster = KubeRayCluster(
+        image=dagster_ray_image,
+        # have have to first run port-forwarding with minikube
+        # we can only init ray after that
+        lifecycle=Lifecycle(wait=False),
+        client=raycluster_client_resource,
+        ray_cluster=RayClusterConfig(
+            metadata={"namespace": NAMESPACE},
+            spec=RayClusterSpec(head_group_spec=head_group_spec, worker_group_specs=worker_group_specs),
+        ),
+        redis_port=get_random_free_port(),
+        cluster_sharing=ClusterSharing(enabled=True, ttl_seconds=0.1),
+    )
+
+    @dg.asset
+    def my_asset(context: dg.AssetExecutionContext, ray_cluster: RayResource):
+        time.sleep(0.1)
+        return "Hello, World!"
+
+    res = dg.materialize(assets=[my_asset], resources={"ray_cluster": ray_cluster})
+    clusters = raycluster_client.list(
+        namespace=ray_cluster.namespace,
+        label_selector=f"dagster/run-id={res.run_id}",
+    )["items"]
+
+    # cluster should be cleaned up since it's only lock has already expired
+    assert len(clusters) == 0
+
+
+def test_delete_kuberay_clusters_job(
+    ray_cluster_resource_skip_cleanup: KubeRayCluster,
+    k8s_with_kuberay: AClusterManager,
+    raycluster_client: RayClusterClient,
+):
+    @dg.asset
+    def my_asset(ray_cluster: RayResource):
+        return 42
+
+    result = dg.materialize(
+        assets=[my_asset],
+        resources={
+            "ray_cluster": ray_cluster_resource_skip_cleanup,
+        },
+    )
+
+    clusters = raycluster_client.list(
+        namespace=ray_cluster_resource_skip_cleanup.namespace,
+        label_selector=f"dagster/run-id={result.run_id}",
+    )["items"]
+
+    assert len(clusters) == 1
+
+    delete_kuberay_clusters.execute_in_process(
+        resources={
+            "raycluster_client": raycluster_client,
+        },
+        run_config=dg.RunConfig(
+            ops={
+                "delete_kuberay_clusters": DeleteKubeRayClustersConfig(
+                    namespace=ray_cluster_resource_skip_cleanup.namespace,
+                    clusters=[
+                        RayClusterRef(
+                            name=clusters[0]["metadata"]["name"],
+                        )
+                    ],
+                )
+            }
+        ),
+    )
+
+    assert not raycluster_client.list(
+        namespace=ray_cluster_resource_skip_cleanup.namespace, label_selector=f"dagster/run-id={result.run_id}"
+    )["items"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,13 @@
 import dagster as dg
+from packaging.version import Version
+
+if Version(dg.__version__) < Version("1.11.6"):
+    from dagster._core.remote_representation import CodeLocationOrigin, InProcessCodeLocationOrigin
+else:
+    from dagster._core.remote_origin import InProcessCodeLocationOrigin, CodeLocationOrigin  # pyright: ignore[reportMissingImports,reportUnusedImport]  # noqa: F401,I001
+
+assert InProcessCodeLocationOrigin is not None
+assert CodeLocationOrigin is not None
 
 
 def get_saved_path(result: dg.ExecuteInProcessResult, asset_name: str) -> str:
@@ -9,3 +18,6 @@ def get_saved_path(result: dg.ExecuteInProcessResult, asset_name: str) -> str:
     )  # type: ignore[index,union-attr]
     assert isinstance(path, str)
     return path
+
+
+__all__ = ["CodeLocationOrigin", "InProcessCodeLocationOrigin", "get_saved_path"]


### PR DESCRIPTION
This PR implements cluster sharing for `KubeRayCluster`​ Dagster resource. Cluster sharing allows reusing the same `RayCluster` created by one of a previously executed Dagster steps across subsequent Dagster steps. It can dramatically speed up step setup, making if effectively instant in the presence of existing clusters.

Because KubeRay [doesn't currently provide a TTL mechanism](https://github.com/ray-project/kuberay/issues/4033) for `RayCluster`​, this PR does 2 things:

1. Shared cluster discovery: `KubeRayCluster.cluster_sharing`​ config is responsible for matching on existing `RayCluster`​ based on system (generated by Dagster and `dagster-ray`) and user-provided Kubernetes labels
2. A custom TTL mechanism based on Kubernetes annotations and a Dagster sensor:
    1. `KubeRayCluster`​ places  `dagster/lock-<run-id>-<step-key>`​ annotations on `RayCluster`​ resources targeted by the current Dagster step. The annotation value is a serialized `ClusterSharingLock`​ object with creation time and ttl set.
    2. `dagster_ray.kuberay.cleanup_expired_rayclusters`​ sensor monitors `RayClsuter`​ resources and submits run requests for expired clusters using `dagster_ray.kuberay.delete_kuberay_rayclusters`​ job.

---

Resolve #131