### PR TITLE
fix: force quoting when dumping runtimeEnvYAML

### DIFF
--- a/src/dagster_ray/kuberay/pipes.py
+++ b/src/dagster_ray/kuberay/pipes.py
@@ -180,7 +180,7 @@ class PipesKubeRayJobClient(dg.PipesClient, TreatAsResourceParam):
         runtime_env["env_vars"] = runtime_env.get("env_vars", {})
         runtime_env["env_vars"].update(env_vars)
 
-        ray_job["spec"]["runtimeEnvYAML"] = yaml.safe_dump(runtime_env)
+        ray_job["spec"]["runtimeEnvYAML"] = yaml.safe_dump(runtime_env, default_style='"')
 
         image_from_run_tag = context.run.tags.get("dagster/image")
 

--- a/tests/kuberay/test_pipes.py
+++ b/tests/kuberay/test_pipes.py
@@ -3,6 +3,7 @@ import sys
 import dagster as dg
 import pytest
 import ray  # noqa: TID253
+import yaml
 from dagster._core.definitions.data_version import (
     DATA_VERSION_IS_USER_PROVIDED_TAG,
     DATA_VERSION_TAG,
@@ -26,6 +27,7 @@ RAY_JOB = {
     "spec": {
         "activeDeadlineSeconds": 10800,
         "entrypoint": ENTRYPOINT,
+        "runtimeEnvYAML": yaml.dump({"env_vars": {"FOO": "1E-5"}}, default_style='"'),
         "entrypointNumCpus": 0.1,
         "rayClusterSpec": {
             "autoscalerOptions": {


### PR DESCRIPTION
This PR addresses the following issue https://github.com/danielgafni/dagster-ray/issues/296.

I have added a minimal `runtimeEnvYAML` to the `RAY_JOB` specification in `tests/kuberay/test_pipes.py` which makes the `test_ray_job_pipes` fail in the current setup, but succeed with the suggested fix.