### PR TITLE
Revert ":sparkles: support worker_process_setup_hook"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,6 @@ All notable user-facing changes to `dagster-ray` will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-#### Added
-
-- `worker_process_setup_hook` parameter of `RuntimeEnv` is now supported (only as a string module path)
-
-#### Fixes
-
-- fixed `env_vars` not being used by `KubeRayInteractiveJob`
-
 ## 0.4.1
 
 ### Added

--- a/src/dagster_ray/_base/resources.py
+++ b/src/dagster_ray/_base/resources.py
@@ -98,10 +98,6 @@ class RayResource(dg.ConfigurableResource, ABC):
         default=False,
         description="Enable legacy debugger: inject `RAY_DEBUG=legacy` into the Ray cluster configuration. Learn more: [KubeRay docs](https://docs.ray.io/en/latest/ray-observability/user-guides/debug-apps/ray-debugging.html#using-the-ray-debugger)",
     )
-    worker_process_setup_hook: str | None = Field(
-        default=None,
-        description="A module path to a function that will be called on each worker process after it starts, but before tasks/actors are scheduled. Must be importable by Ray workers. More details in [Ray docs](https://docs.ray.io/en/latest/ray-core/api/doc/ray.runtime_env.RuntimeEnv.html).",
-    )
 
     _context: RayBaseContext | None = PrivateAttr()
 
@@ -221,9 +217,6 @@ class RayResource(dg.ConfigurableResource, ABC):
 
         for var, value in self.get_env_vars_to_inject().items():
             init_options["runtime_env"]["env_vars"][var] = value
-
-        if self.worker_process_setup_hook is not None:
-            init_options["runtime_env"]["worker_process_setup_hook"] = self.worker_process_setup_hook
 
         self.data_execution_options.apply()
 

--- a/src/dagster_ray/configs.py
+++ b/src/dagster_ray/configs.py
@@ -38,10 +38,6 @@ class RayExecutionConfig(dg.Config):
     num_gpus: float | None = Field(default=None, description="The number of GPUs to allocate.")
     memory: int | None = Field(default=None, description="The amount of memory in bytes to allocate.")
     resources: dict[str, float] | None = Field(default=None, description="Custom resources to allocate.")
-    worker_process_setup_hook: str | None = Field(
-        default=None,
-        description="A module path to a function that will be called on each worker process after it starts, but before tasks/actors are scheduled. Must be importable by Ray workers.",
-    )
 
     @classmethod
     def from_tags(cls, tags: Mapping[str, str]) -> RayExecutionConfig:

--- a/src/dagster_ray/core/executor.py
+++ b/src/dagster_ray/core/executor.py
@@ -114,7 +114,6 @@ def ray_executor(init_context: InitExecutorContext) -> Executor:
             num_gpus=ray_cfg.num_gpus,
             memory=ray_cfg.memory,
             resources=ray_cfg.resources,
-            worker_process_setup_hook=ray_cfg.worker_process_setup_hook,
         ),
         retries=RetryMode.from_config(exc_cfg["retries"]),  # type: ignore
         max_concurrent=dg._check.opt_int_elem(exc_cfg, "max_concurrent"),
@@ -137,7 +136,6 @@ class RayStepHandler(StepHandler):
         num_gpus: float | None,
         memory: int | None,
         resources: dict[str, float] | None,
-        worker_process_setup_hook: str | None = None,
     ):
         super().__init__()
 
@@ -148,7 +146,6 @@ class RayStepHandler(StepHandler):
         self.num_gpus = num_gpus
         self.memory = memory
         self.resources = resources
-        self.worker_process_setup_hook = worker_process_setup_hook
 
     def _get_step_key(self, step_handler_context: StepHandlerContext) -> str:
         step_keys_to_execute = cast(list[str], step_handler_context.execute_step_args.step_keys_to_execute)
@@ -206,10 +203,6 @@ class RayStepHandler(StepHandler):
         runtime_env["env_vars"] = {**dagster_env_vars, **runtime_env.get("env_vars", {})}  # type: ignore
 
         runtime_env["env_vars"].update(resolve_env_vars_list(self.env_vars))
-
-        worker_process_setup_hook = user_provided_config.worker_process_setup_hook or self.worker_process_setup_hook
-        if worker_process_setup_hook is not None:
-            runtime_env["worker_process_setup_hook"] = worker_process_setup_hook
 
         num_cpus = self.num_cpus or user_provided_config.num_cpus
         num_gpus = self.num_gpus or user_provided_config.num_gpus

--- a/src/dagster_ray/core/run_launcher.py
+++ b/src/dagster_ray/core/run_launcher.py
@@ -91,7 +91,6 @@ class RayRunLauncher(RunLauncher, ConfigurableClass):
         num_gpus: int | None = None,
         memory: int | None = None,
         resources: dict[str, float] | None = None,
-        worker_process_setup_hook: str | None = None,
         inst_data: ConfigurableClassData | None = None,
     ):
         self._inst_data = dg._check.opt_inst_param(inst_data, "inst_data", ConfigurableClassData)
@@ -106,7 +105,6 @@ class RayRunLauncher(RunLauncher, ConfigurableClass):
         self.num_gpus = num_gpus
         self.memory = memory
         self.resources = resources
-        self.worker_process_setup_hook = worker_process_setup_hook
 
         super().__init__()
 
@@ -200,10 +198,6 @@ class RayRunLauncher(RunLauncher, ConfigurableClass):
                 "DAGSTER_RUN_JOB_NAME": job_origin.job_name,
             }
         )
-
-        worker_process_setup_hook = cfg_from_tags.worker_process_setup_hook or self.worker_process_setup_hook
-        if worker_process_setup_hook is not None:
-            runtime_env["worker_process_setup_hook"] = worker_process_setup_hook
 
         self._instance.report_engine_event(
             "Creating Ray run job",

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,6 +1,5 @@
 import os
 from typing import Any
-from unittest.mock import patch
 
 import dagster as dg
 import pytest
@@ -50,46 +49,6 @@ def test_debug_mode():
             instance=instance,
             resources={"ray_cluster": ray_cluster},
         )
-
-
-def test_worker_process_setup_hook():
-    import ray
-
-    from dagster_ray.configs import RayDataExecutionOptions
-
-    ray_cluster = LocalRay(worker_process_setup_hook="my_module.setup")
-
-    with (
-        patch.object(ray, "init", return_value=None) as mock_init,
-        patch.object(RayDataExecutionOptions, "apply"),
-        patch.object(RayDataExecutionOptions, "apply_remote"),
-    ):
-        ray_cluster.connect(dg.build_init_resource_context())
-
-    _, kwargs = mock_init.call_args
-    assert kwargs["runtime_env"]["worker_process_setup_hook"] == "my_module.setup"
-
-
-def test_worker_process_setup_hook_explicit_overrides_runtime_env():
-    """Explicit field takes priority over runtime_env dict key."""
-    import ray
-
-    from dagster_ray.configs import RayDataExecutionOptions
-
-    ray_cluster = LocalRay(
-        worker_process_setup_hook="my_module.explicit",
-        ray_init_options={"runtime_env": {"worker_process_setup_hook": "my_module.from_dict"}},
-    )
-
-    with (
-        patch.object(ray, "init", return_value=None) as mock_init,
-        patch.object(RayDataExecutionOptions, "apply"),
-        patch.object(RayDataExecutionOptions, "apply_remote"),
-    ):
-        ray_cluster.connect(dg.build_init_resource_context())
-
-    _, kwargs = mock_init.call_args
-    assert kwargs["runtime_env"]["worker_process_setup_hook"] == "my_module.explicit"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Reverts danielgafni/dagster-ray#304. 

Actually it can always be set via `runtime_env` and doesn't seem like it needs to be a top-level option. 