### PR TITLE
fix(core): write use_polars_sort to Ray DatasetContext

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## Unreleased
+
+### :bug: Bug Fixes
+
+- avoid Ray 2.55 `DatasetContext.use_polars` DeprecationWarning on every `RayDataExecutionOptions.apply()` by writing to `use_polars_sort` ([#354](https://github.com/danielgafni/dagster-ray/issues/354))
+
+### :hammer_and_wrench: Other Improvements
+
+- add `RayDataExecutionOptions.use_polars_sort`; keep `use_polars` as a deprecated alias that forwards its value and emits a `DeprecationWarning`
+
 ## v0.4.4 (26-03-2026)
 
 ### :sparkles: Features

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,16 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## Unreleased
-
-### :bug: Bug Fixes
-
-- avoid Ray 2.55 `DatasetContext.use_polars` DeprecationWarning on every `RayDataExecutionOptions.apply()` by writing to `use_polars_sort` ([#354](https://github.com/danielgafni/dagster-ray/issues/354))
-
-### :hammer_and_wrench: Other Improvements
-
-- add `RayDataExecutionOptions.use_polars_sort`; keep `use_polars` as a deprecated alias that forwards its value and emits a `DeprecationWarning`
-
 ## v0.4.4 (26-03-2026)
 
 ### :sparkles: Features

--- a/src/dagster_ray/configs.py
+++ b/src/dagster_ray/configs.py
@@ -84,8 +84,7 @@ class RayDataExecutionOptions(dg.Config):
     )
     use_polars: bool | None = Field(
         default=None,
-        description="Deprecated. Use `use_polars_sort` instead. Ray 2.55 renamed the underlying `DatasetContext` attribute to `use_polars_sort`.",
-        deprecated="`use_polars` is deprecated; use `use_polars_sort` instead.",
+        deprecated="`use_polars` is deprecated and will be removed in dagster-ray 0.5.0; use `use_polars_sort` instead.",
     )
 
     @model_validator(mode="before")
@@ -118,14 +117,10 @@ class RayDataExecutionOptions(dg.Config):
         )
 
         ctx.verbose_progress = self.verbose_progress
-        # Ray >=2.50 renamed the sort-time Polars toggle from `use_polars` to
-        # `use_polars_sort`; read the effective value (the legacy field wins when
-        # both are set only because the validator has already unified them).
-        effective = self.use_polars if self.use_polars is not None else self.use_polars_sort
         if Version(ray.__version__) >= Version("2.50"):
-            ctx.use_polars_sort = effective
+            ctx.use_polars_sort = self.use_polars_sort
         else:
-            ctx.use_polars = effective
+            ctx.use_polars = self.use_polars_sort
 
     def apply_remote(self):
         import ray

--- a/src/dagster_ray/configs.py
+++ b/src/dagster_ray/configs.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Mapping
 from typing import Any, Literal
 
 import dagster as dg
+from packaging.version import Version
 from pydantic import Field, model_validator
 
 USER_DEFINED_RAY_KEY = "dagster-ray/config"
@@ -91,17 +91,18 @@ class RayDataExecutionOptions(dg.Config):
     @model_validator(mode="before")
     @classmethod
     def _forward_deprecated_use_polars(cls, data: Any) -> Any:
-        if not isinstance(data, dict) or data.get("use_polars") is None:
+        if not isinstance(data, dict):
             return data
-        warnings.warn(
-            "`use_polars` is deprecated; use `use_polars_sort` instead. "
-            "The value has been forwarded to `use_polars_sort`.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # Prefer an explicit `use_polars_sort`; otherwise forward the deprecated value.
-        # Keep `use_polars` on the instance so existing read access keeps working.
-        data = {**data, "use_polars_sort": data.get("use_polars_sort", data["use_polars"])}
+        legacy = data.get("use_polars")
+        new = data.get("use_polars_sort")
+        if legacy is not None and new is not None and legacy != new:
+            raise ValueError(
+                "`use_polars` and `use_polars_sort` were set to contradicting values "
+                f"({legacy!r} vs {new!r}). `use_polars` is deprecated; set only "
+                "`use_polars_sort`."
+            )
+        if legacy is not None and new is None:
+            data = {**data, "use_polars_sort": legacy}
         return data
 
     def apply(self):
@@ -117,12 +118,14 @@ class RayDataExecutionOptions(dg.Config):
         )
 
         ctx.verbose_progress = self.verbose_progress
-        # Ray >=2.50 renamed `use_polars` to `use_polars_sort`; set the new name when
-        # available to avoid Ray's own DeprecationWarning, and fall back on older Ray.
-        if hasattr(ctx, "use_polars_sort"):
-            ctx.use_polars_sort = self.use_polars_sort
+        # Ray >=2.50 renamed the sort-time Polars toggle from `use_polars` to
+        # `use_polars_sort`; read the effective value (the legacy field wins when
+        # both are set only because the validator has already unified them).
+        effective = self.use_polars if self.use_polars is not None else self.use_polars_sort
+        if Version(ray.__version__) >= Version("2.50"):
+            ctx.use_polars_sort = effective
         else:
-            ctx.use_polars = self.use_polars_sort
+            ctx.use_polars = effective
 
     def apply_remote(self):
         import ray

--- a/src/dagster_ray/configs.py
+++ b/src/dagster_ray/configs.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping
 from typing import Any, Literal
 
 import dagster as dg
-from pydantic import Field
+from pydantic import Field, model_validator
 
 USER_DEFINED_RAY_KEY = "dagster-ray/config"
 DAGSTER_RAY_NAMESPACES_ENV_VAR = "DAGSTER_RAY_NAMESPACES"
@@ -77,7 +78,31 @@ class RayDataExecutionOptions(dg.Config):
     cpu_limit: int = 5000
     gpu_limit: int = 0
     verbose_progress: bool = True
-    use_polars: bool = True
+    use_polars_sort: bool = Field(
+        default=True,
+        description="Whether to use Polars for sort operations in Ray Data. Forwarded to `ray.data.DatasetContext.use_polars_sort`.",
+    )
+    use_polars: bool | None = Field(
+        default=None,
+        description="Deprecated. Use `use_polars_sort` instead. Ray 2.55 renamed the underlying `DatasetContext` attribute to `use_polars_sort`.",
+        deprecated="`use_polars` is deprecated; use `use_polars_sort` instead.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _forward_deprecated_use_polars(cls, data: Any) -> Any:
+        if not isinstance(data, dict) or data.get("use_polars") is None:
+            return data
+        warnings.warn(
+            "`use_polars` is deprecated; use `use_polars_sort` instead. "
+            "The value has been forwarded to `use_polars_sort`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        # Prefer an explicit `use_polars_sort`; otherwise forward the deprecated value.
+        # Keep `use_polars` on the instance so existing read access keeps working.
+        data = {**data, "use_polars_sort": data.get("use_polars_sort", data["use_polars"])}
+        return data
 
     def apply(self):
         import ray
@@ -92,7 +117,7 @@ class RayDataExecutionOptions(dg.Config):
         )
 
         ctx.verbose_progress = self.verbose_progress
-        ctx.use_polars = self.use_polars
+        ctx.use_polars_sort = self.use_polars_sort
 
     def apply_remote(self):
         import ray

--- a/src/dagster_ray/configs.py
+++ b/src/dagster_ray/configs.py
@@ -117,7 +117,12 @@ class RayDataExecutionOptions(dg.Config):
         )
 
         ctx.verbose_progress = self.verbose_progress
-        ctx.use_polars_sort = self.use_polars_sort
+        # Ray >=2.50 renamed `use_polars` to `use_polars_sort`; set the new name when
+        # available to avoid Ray's own DeprecationWarning, and fall back on older Ray.
+        if hasattr(ctx, "use_polars_sort"):
+            ctx.use_polars_sort = self.use_polars_sort
+        else:
+            ctx.use_polars = self.use_polars_sort
 
     def apply_remote(self):
         import ray

--- a/src/dagster_ray/configs.py
+++ b/src/dagster_ray/configs.py
@@ -90,19 +90,21 @@ class RayDataExecutionOptions(dg.Config):
     @model_validator(mode="before")
     @classmethod
     def _forward_deprecated_use_polars(cls, data: Any) -> Any:
-        if not isinstance(data, dict):
+        if not isinstance(data, dict) or "use_polars" not in data:
             return data
-        legacy = data.get("use_polars")
-        new = data.get("use_polars_sort")
-        if legacy is not None and new is not None and legacy != new:
-            raise ValueError(
-                "`use_polars` and `use_polars_sort` were set to contradicting values "
-                f"({legacy!r} vs {new!r}). `use_polars` is deprecated; set only "
-                "`use_polars_sort`."
-            )
-        if legacy is not None and new is None:
-            data = {**data, "use_polars_sort": legacy}
-        return data
+        legacy = data["use_polars"]
+        if legacy is None:
+            return data
+        if "use_polars_sort" in data:
+            new = data["use_polars_sort"]
+            if new != legacy:
+                raise ValueError(
+                    "`use_polars` and `use_polars_sort` were set to contradicting values "
+                    f"({legacy!r} vs {new!r}). `use_polars` is deprecated; set only "
+                    "`use_polars_sort`."
+                )
+            return data
+        return {**data, "use_polars_sort": legacy}
 
     def apply(self):
         import ray

--- a/src/dagster_ray/kuberay/client/raycluster/client.py
+++ b/src/dagster_ray/kuberay/client/raycluster/client.py
@@ -139,7 +139,11 @@ class RayClusterClient(BaseKubeRayClient[RayClusterStatus]):
             stop=stop_after_attempt(30),
             wait=wait_fixed(2),
             retry=(
-                retry_if_exception_type(urllib3.exceptions.ProtocolError)
+                # ProtocolError: mid-response network drops (e.g. RemoteDisconnected).
+                # MaxRetryError: urllib3's pool-level retries exhausted — typically
+                # wraps NewConnectionError ("Connection refused") when the apiserver
+                # briefly goes away (common on minikube under load in CI).
+                retry_if_exception_type((urllib3.exceptions.ProtocolError, urllib3.exceptions.MaxRetryError))
                 # transient K8s API errors during cluster startup (e.g. 404 when the resource doesn't exist yet)
                 | retry_if_exception(is_retryable_k8s_api_exception)
             ),

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,11 +1,43 @@
 from __future__ import annotations
 
+import sys
 import warnings
+from types import ModuleType, SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
 
 from dagster_ray.configs import RayDataExecutionOptions
+
+
+class _FakeExecutionResources:
+    @staticmethod
+    def for_limits(
+        cpu: int | None,
+        gpu: int | None,
+        object_store_memory: int | None,
+    ) -> tuple[int | None, int | None, int | None]:
+        return cpu, gpu, object_store_memory
+
+
+def _install_fake_ray(monkeypatch: pytest.MonkeyPatch, ray_version: str) -> SimpleNamespace:
+    context = SimpleNamespace(execution_options=SimpleNamespace(resource_limits=None), verbose_progress=None)
+
+    ray_module = ModuleType("ray")
+    ray_data_module = ModuleType("ray.data")
+
+    def get_current() -> SimpleNamespace:
+        return context
+
+    setattr(ray_data_module, "DatasetContext", SimpleNamespace(get_current=get_current))
+    setattr(ray_data_module, "ExecutionResources", _FakeExecutionResources)
+    setattr(ray_module, "__version__", ray_version)
+    setattr(ray_module, "data", ray_data_module)
+
+    monkeypatch.setitem(sys.modules, "ray", ray_module)
+    monkeypatch.setitem(sys.modules, "ray.data", ray_data_module)
+
+    return context
 
 
 def test_use_polars_sort_defaults_to_true():
@@ -44,3 +76,24 @@ def test_use_polars_sort_alone_does_not_warn_on_construction():
     ours = [w for w in caught if "use_polars" in str(w.message)]
     assert ours == []
     assert opts.use_polars_sort is False
+
+
+@pytest.mark.parametrize(
+    ("ray_version", "expected_polars_attr"),
+    [
+        ("2.55.0", "use_polars_sort"),
+        ("2.49.0", "use_polars"),
+    ],
+)
+def test_apply_writes_forwarded_legacy_value_to_ray_version_specific_context_attr(
+    monkeypatch: pytest.MonkeyPatch,
+    ray_version: str,
+    expected_polars_attr: str,
+):
+    context = _install_fake_ray(monkeypatch, ray_version)
+
+    RayDataExecutionOptions(use_polars=False).apply()
+
+    assert context.execution_options.resource_limits == (None, None, None)
+    assert context.verbose_progress is True
+    assert getattr(context, expected_polars_attr) is False

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from dagster_ray.configs import RayDataExecutionOptions
+
+
+def test_use_polars_sort_defaults_to_true():
+    opts = RayDataExecutionOptions()
+    assert opts.use_polars_sort is True
+    assert opts.use_polars is None
+
+
+def test_deprecated_use_polars_is_forwarded_to_use_polars_sort():
+    with pytest.warns(DeprecationWarning, match="use_polars_sort"):
+        opts = RayDataExecutionOptions(use_polars=False)
+    assert opts.use_polars_sort is False
+    # read-back of the deprecated attribute is preserved for backward compatibility
+    assert opts.use_polars is False
+
+
+def test_explicit_use_polars_sort_wins_over_deprecated_alias():
+    with pytest.warns(DeprecationWarning):
+        opts = RayDataExecutionOptions(use_polars=True, use_polars_sort=False)
+    assert opts.use_polars_sort is False
+
+
+def test_use_polars_sort_alone_does_not_warn_on_construction():
+    # Construction with only the new field must not emit our deprecation warning.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        opts = RayDataExecutionOptions(use_polars_sort=False)
+    ours = [w for w in caught if "use_polars_sort" in str(w.message) and "deprecated" in str(w.message).lower()]
+    assert ours == []
+    assert opts.use_polars_sort is False

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import warnings
 
 import pytest
+from pydantic import ValidationError
 
 from dagster_ray.configs import RayDataExecutionOptions
 
@@ -10,28 +11,36 @@ from dagster_ray.configs import RayDataExecutionOptions
 def test_use_polars_sort_defaults_to_true():
     opts = RayDataExecutionOptions()
     assert opts.use_polars_sort is True
-    assert opts.use_polars is None
+    # accessing the deprecated field emits a warning, so silence it for this assertion
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert opts.use_polars is None
 
 
 def test_deprecated_use_polars_is_forwarded_to_use_polars_sort():
+    opts = RayDataExecutionOptions(use_polars=False)
+    assert opts.use_polars_sort is False
+    # reading the deprecated attribute warns and preserves backward compatibility
     with pytest.warns(DeprecationWarning, match="use_polars_sort"):
-        opts = RayDataExecutionOptions(use_polars=False)
-    assert opts.use_polars_sort is False
-    # read-back of the deprecated attribute is preserved for backward compatibility
-    assert opts.use_polars is False
+        assert opts.use_polars is False
 
 
-def test_explicit_use_polars_sort_wins_over_deprecated_alias():
-    with pytest.warns(DeprecationWarning):
-        opts = RayDataExecutionOptions(use_polars=True, use_polars_sort=False)
-    assert opts.use_polars_sort is False
+def test_use_polars_and_use_polars_sort_in_agreement_is_accepted():
+    opts = RayDataExecutionOptions(use_polars=True, use_polars_sort=True)
+    assert opts.use_polars_sort is True
+
+
+def test_use_polars_and_use_polars_sort_contradicting_raises():
+    with pytest.raises(ValidationError, match="contradicting values"):
+        RayDataExecutionOptions(use_polars=True, use_polars_sort=False)
+    with pytest.raises(ValidationError, match="contradicting values"):
+        RayDataExecutionOptions(use_polars=False, use_polars_sort=True)
 
 
 def test_use_polars_sort_alone_does_not_warn_on_construction():
-    # Construction with only the new field must not emit our deprecation warning.
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         opts = RayDataExecutionOptions(use_polars_sort=False)
-    ours = [w for w in caught if "use_polars_sort" in str(w.message) and "deprecated" in str(w.message).lower()]
+    ours = [w for w in caught if "use_polars" in str(w.message)]
     assert ours == []
     assert opts.use_polars_sort is False


### PR DESCRIPTION
## Summary

Closes #354

## Changelog

`RayDataExecutionOptions.use_polars` has been deprecated in favor of `RayDataExecutionOptions.use_polars_sort`