### PR TITLE
fix(kuberay): preserve useful characters when truncating K8s label values

### DIFF
--- a/src/dagster_ray/kuberay/utils.py
+++ b/src/dagster_ray/kuberay/utils.py
@@ -26,14 +26,24 @@ def is_retryable_k8s_api_exception(e: BaseException) -> bool:
     return isinstance(e, ApiException) and e.status in RETRYABLE_K8S_STATUSES
 
 
+# K8s label-value character set and regex are defined at:
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+# Allowed interior characters: alphanumerics, `-`, `_`, `.`.
 _INVALID_CHARS_PATTERN = re.compile(r"[^a-zA-Z0-9\-_.]")
-_LEADING_TRAILING_NON_ALNUM_PATTERN = re.compile(r"^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$")
+# Leading/trailing characters must be alphanumeric; these patterns strip
+# anything else on each end.
+_LEADING_NON_ALNUM_PATTERN = re.compile(r"^[^a-zA-Z0-9]+")
+_TRAILING_NON_ALNUM_PATTERN = re.compile(r"[^a-zA-Z0-9]+$")
+# Full K8s label-value regex (must also satisfy <=63 chars).
+_K8S_LABEL_VALUE_PATTERN = re.compile(r"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")
 
 
 def normalize_k8s_label_values(labels: dict[str, str]) -> dict[str, str]:
     """Normalize label values to comply with Kubernetes requirements.
 
-    K8s label values must match: (([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?
+    Per the K8s label spec
+    (https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set),
+    label values must match: ``(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?``
     - Start and end with alphanumeric
     - Middle can contain alphanumeric, -, _, .
     - Max 63 characters
@@ -58,11 +68,24 @@ def normalize_k8s_label_values(labels: dict[str, str]) -> dict[str, str]:
         # Collapse multiple consecutive hyphens into a single hyphen
         value = re.sub(r"-+", "-", value)
 
-        # Remove leading/trailing non-alphanumeric characters
-        value = _LEADING_TRAILING_NON_ALNUM_PATTERN.sub("", value)
+        # Strip leading non-alphanumerics first so the 63-char budget is
+        # spent on useful content (e.g. `___useful-tail` keeps `useful-tail`
+        # rather than truncating into a run of `_`).
+        value = _LEADING_NON_ALNUM_PATTERN.sub("", value)
+        # Truncate to 63 characters.
+        value = value[:63]
+        # Strip trailing non-alphanumerics — the character at position 63 may
+        # be `_`, `-`, or `.`, which would violate the K8s label-value regex.
+        value = _TRAILING_NON_ALNUM_PATTERN.sub("", value)
 
-        # Truncate to 63 characters
-        normalized[key] = value[:63]
+        if not _K8S_LABEL_VALUE_PATTERN.match(value):
+            raise ValueError(
+                f"Normalized label value for key {key!r} does not match the "
+                f"K8s label-value regex {_K8S_LABEL_VALUE_PATTERN.pattern!r}: "
+                f"{value!r}"
+            )
+
+        normalized[key] = value
 
     # replace keys starting with `dagster.io/` with `dagster/`
     normalized_with_fixed_dagster_keys = {}

--- a/tests/kuberay/test_utils.py
+++ b/tests/kuberay/test_utils.py
@@ -1,8 +1,22 @@
+import re
+
+import pytest
+
 from dagster_ray.kuberay.utils import normalize_k8s_label_values
+
+# From the K8s label-value spec:
+# https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+_K8S_LABEL_VALUE = re.compile(r"^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$")
+
+
+def _assert_all_k8s_valid(labels: dict[str, str]) -> None:
+    for k, v in labels.items():
+        assert len(v) <= 63, f"{k!r}: value longer than 63 chars: {v!r}"
+        assert _K8S_LABEL_VALUE.match(v), f"{k!r}: value violates K8s label regex: {v!r}"
 
 
 def test_normalize_k8s_label_values(snapshot):
-    assert snapshot == normalize_k8s_label_values(
+    out = normalize_k8s_label_values(
         {
             "foo": "bar",
             "my/label": "my/value",
@@ -14,7 +28,71 @@ def test_normalize_k8s_label_values(snapshot):
             "badstart_after_initial_replace": "@foo",
         }
     )
+    assert snapshot == out
+    _assert_all_k8s_valid(out)
 
 
 def test_normalize_k8s_label_values_important_labels():
-    assert normalize_k8s_label_values({"dagster/run-id": "12345"}) == {"dagster/run-id": "12345"}
+    out = normalize_k8s_label_values({"dagster/run-id": "12345"})
+    assert out == {"dagster/run-id": "12345"}
+    _assert_all_k8s_valid(out)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Git branch name > 63 chars whose 63rd char is `_`. Regression for
+        # KubeRay RayCluster creation failing with
+        # `metadata.labels: Invalid value … must start and end with an
+        # alphanumeric character` when a PR's long branch name was being
+        # stuck into a `dagster/git-branch`-style label.
+        "04-22-datastack_reshape_metaxy_map-entry_columns_on_inputmodel_"
+        "to_silence_spurious_pydantic_serializer_warnings_in_ray_workers",
+        # Truncation landing on `.`
+        "a" * 63 + "." + "b" * 10,
+        # Truncation landing on `-`
+        "a" * 63 + "-" + "b" * 10,
+        # Collapsed-hyphen run exactly at position 63.
+        "a" * 62 + "--" + "b" * 10,
+        # Leading non-alnum run that does NOT collapse (`_` / `.` are not
+        # collapsed like `-+` is). If we truncated first, these would eat the
+        # 63-char budget and we'd strip the whole thing to empty. Stripping
+        # leading first preserves the useful tail.
+        "_" * 40 + "useful-and-specific-branch-name-that-should-survive",
+        "." * 40 + "useful-and-specific-branch-name-that-should-survive",
+        # Daniel's case: leading garbage of chars that the invalid-char
+        # replacement turns into `-` (and then collapses), followed by a
+        # useful tail that we want to keep.
+        "§" * 39 + "-finally-something-useful-and-specific-that-should-survive",
+    ],
+)
+def test_normalize_k8s_label_values_truncated_tail_is_alphanumeric(value: str) -> None:
+    """Truncation to 63 chars must never leave a trailing non-alphanumeric
+    character; doing so produces a label value that K8s rejects with HTTP 422."""
+    out = normalize_k8s_label_values({"k": value})["k"]
+
+    assert len(out) <= 63
+    assert out == "" or out[-1].isalnum(), f"label ends non-alphanumeric: {out!r}"
+    assert _K8S_LABEL_VALUE.match(out), f"value violates K8s label regex: {out!r}"
+
+
+def test_normalize_k8s_label_values_preserves_useful_tail_after_leading_garbage() -> None:
+    """Stripping leading non-alphanumerics before truncation preserves useful
+    characters when the input has a long leading non-alnum run. Truncating
+    first would eat the budget on characters we'd immediately strip."""
+    useful = "useful-and-specific-branch-name-that-should-survive"
+    out = normalize_k8s_label_values({"k": "_" * 40 + useful})
+    assert out["k"].startswith("useful"), out
+    _assert_all_k8s_valid(out)
+
+
+def test_normalize_k8s_label_values_rejects_unexpectedly_invalid_output(monkeypatch) -> None:
+    """The final K8s-regex check at label creation time should raise if
+    normalization ever produces an invalid value."""
+    import dagster_ray.kuberay.utils as utils_mod
+
+    # Force the trailing-strip to be a no-op to simulate a normalization bug.
+    # Input: 62 `a`s + `_` + 10 `b`s — truncation to 63 leaves `_` at the tail.
+    monkeypatch.setattr(utils_mod, "_TRAILING_NON_ALNUM_PATTERN", re.compile(r"(?!)"))
+    with pytest.raises(ValueError, match="K8s label-value regex"):
+        utils_mod.normalize_k8s_label_values({"k": "a" * 62 + "_" + "b" * 10})


### PR DESCRIPTION
## Problem

`normalize_k8s_label_values` strips leading/trailing non-alphanumeric chars **before** truncating to 63. For long inputs (e.g. a branch name stuck into `dagster/git-branch`), the 63rd character can be `_`, `-`, or `.`, which fails the K8s label-value regex `(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?`. This breaks `RayClusterResource` creation with HTTP 422, cascading into a 404 at cleanup.

## Fix

Split the leading/trailing strip into two steps around the truncation:

1. Strip leading non-alphanumerics — so a leading `_` / `.` run doesn't eat the 63-char budget on characters we'd immediately strip anyway.
2. Truncate to 63.
3. Strip trailing non-alphanumerics — handles whatever character truncation lands on.

Then validate the result against the K8s label-value regex and raise if it doesn't match, so any future regression in this function surfaces at normalize time instead of at the K8s API.

## Tests

- The existing snapshot test now also checks every output against the K8s label-value regex.
- `test_normalize_k8s_label_values_truncated_tail_is_alphanumeric` is extended with long leading `_` / `.` runs and the `§`-style leading-garbage case from the review.
- New `test_normalize_k8s_label_values_preserves_useful_tail_after_leading_garbage` pins the "useful tail survives" property.
- New `test_normalize_k8s_label_values_rejects_unexpectedly_invalid_output` patches the trailing-strip to a no-op and asserts the K8s-regex validation raises.