### PR TITLE
feat(kuberay): publish heartbeats for Dagster steps running on shared Ray clusters

### DIFF
--- a/docs/api/kuberay.md
+++ b/docs/api/kuberay.md
@@ -112,6 +112,11 @@ These resources initialize Ray client connection with a remote cluster.
       inherited_members: true
       members: null
 
+::: dagster_ray.kuberay.configs.ClusterSharingHeartbeat
+    options:
+      inherited_members: true
+      members: null
+
 ---
 
 ::: dagster_ray.kuberay.resources.base.BaseKubeRayResource

--- a/docs/tutorial/kuberay.md
+++ b/docs/tutorial/kuberay.md
@@ -171,7 +171,8 @@ When enabled, `dagster-ray` will use configured user-provided and dagster-genera
 - `dagster/git-sha`
 - `dagster/resource-key`
 
-Each time a cluster is chosen for a step, `dagster-ray` will apply an annotation to the selected cluster to indicate that it's being used by the current step. This annotation effectively extends the cluster sharing TTL by the configured `ttl_seconds` amount. Note that the countdown for the TTL starts from the time the annotation is applied, not from the time when the Ray job starts.
+Each time a cluster is chosen for a step, `dagster-ray` will apply and continuously update a heartbeat lock annotation to the selected cluster to indicate that it's currently in use by the step.
+The lock is considered expired once `ttl_seconds` has passed since its last heartbeat and may be deleted by [garbage collection](#raycluster-garbage-collection).
 
 Configuration options for cluster sharing can be found [here](../api/kuberay.md#dagster_ray.kuberay.KubeRayCluster.cluster_sharing).
 
@@ -181,18 +182,23 @@ A `RayCluster` created by `dagster-ray` may become dangling for two reasons:
 - the Dagster step process exits unexpectedly (e.g. OOM), missing the change to run cleanup
 - if [Cluster Sharing](#cluster-sharing) is used **and** the cluster did not expire at the time of the Dagster step completion
 
+
 Since `RayCluster` doesn't support native garbage collection yet (see [TTL](https://github.com/ray-project/kuberay/issues/4033) and [idle termination](https://github.com/ray-project/kuberay/issues/2998) feature requests), `dagster-ray` provides a custom garbage collection Dagster sensor.
 
 ```py
 import dagster as dg
-from dagster_ray.kuberay import cleanup_expired_rayclusters
+from dagster_ray.kuberay import cleanup_expired_kuberay_clusters
 
 defs = dg.Definitions(
-    sensors=[cleanup_expired_rayclusters],
+    sensors=[cleanup_expired_kuberay_clusters],
 )
 ```
 
-It's not recommended for production environments as it will interrupt active long-running jobs and is not safe by any means. It's intended to be used with short-running development environments where job interruption is acceptable.
+The sensor deletes shared clusters once all of their locks have expired — a lock expires when the time since its last heartbeat exceeds the TTL.
+
+!!! tip
+
+    You can configure [run timeouts](https://docs.dagster.io/deployment/execution/run-monitoring#general-run-timeouts) to prevent Dagster steps from hanging indefinitely.
 
 ## PipesKubeRayJobClient
 

--- a/src/dagster_ray/_base/cluster_sharing_lock.py
+++ b/src/dagster_ray/_base/cluster_sharing_lock.py
@@ -1,5 +1,6 @@
 import logging
-from collections.abc import Sequence
+import threading
+from collections.abc import Callable, Sequence
 from datetime import datetime, timedelta
 
 from pydantic import BaseModel, Field, ValidationError
@@ -12,7 +13,13 @@ class ClusterSharingLock(BaseModel):
     run_id: str = Field(description="The ID of the Dagster run that placed the lock.")
     key: str = Field(description="The key of the Dagster step that placed the lock, any unique identifier.")
     created_at: datetime = Field(description="The time at which the lock was created.")
-    ttl_seconds: float = Field(description="Time to live for the lock after which it's considered expired.")
+    ttl_seconds: float = Field(
+        description="Time to live for the lock after which it's considered expired. Counted from the last sign of life (`heartbeat_at` if present, otherwise `created_at`)."
+    )
+    heartbeat_at: datetime | None = Field(
+        default=None,
+        description="The time of the last heartbeat renewal. `None` if the lock has never been renewed, for example when the heartbeat is disabled or the lock was placed by an older version of `dagster-ray`.",
+    )
 
     @property
     def identifier(self) -> str:
@@ -23,12 +30,21 @@ class ClusterSharingLock(BaseModel):
         return f"dagster/lock-{self.identifier}"[:63]  # 63 is the limit for k8s
 
     @property
+    def alive_at(self) -> datetime:
+        """The last sign of life: the last heartbeat, or the lock creation time."""
+        return self.heartbeat_at or self.created_at
+
+    @property
     def expired_at(self) -> datetime:
-        return self.created_at + timedelta(seconds=self.ttl_seconds)
+        return self.alive_at + timedelta(seconds=self.ttl_seconds)
 
     @property
     def is_expired(self) -> bool:
-        return self.created_at + timedelta(seconds=self.ttl_seconds) < datetime.now()
+        return self.expired_at < datetime.now()
+
+    def renewed(self) -> Self:
+        """A copy of the lock with a fresh `heartbeat_at`. `created_at` is preserved."""
+        return self.model_copy(update={"heartbeat_at": datetime.now()})
 
     @classmethod
     def parse_all_locks(cls, data: dict[str, str]) -> Sequence[Self]:
@@ -47,4 +63,74 @@ class ClusterSharingLock(BaseModel):
 
     @classmethod
     def get_alive_locks(cls, locks: Sequence[Self]) -> Sequence[Self]:
+        """Locks that have not expired.
+
+        A lock expires `ttl_seconds` after its last sign of life (`heartbeat_at` or `created_at`),
+        so a lock with an actively heartbeating step never expires.
+        """
         return [lock for lock in locks if not lock.is_expired]
+
+
+class ClusterSharingLockHeartbeat:
+    """Renews a cluster sharing lock in a background thread while the Dagster step is running.
+
+    Without renewal, the lock expires `ttl_seconds` after step start — even if the step is still
+    using the cluster — and the garbage collection sensor may delete the cluster mid-step. The
+    heartbeat re-stamps the lock's `heartbeat_at` on a timer for as long as the step is alive.
+    This keeps `ttl_seconds` short — idle clusters are still reaped promptly — while long active
+    steps survive.
+
+    The first renewal happens immediately rather than after one interval, so the lock is protected
+    from the moment the heartbeat starts and the startup gap never counts against `ttl_seconds`.
+    This matters most when the lock already carries some age, or when `interval_seconds` is a large
+    fraction of `ttl_seconds`, where a first renewal delayed by a full interval could land after the
+    lock has expired.
+
+    Renewal failures (e.g. the cluster was already deleted, or a transient API error) are logged
+    and do not stop the loop. The thread is a daemon: if the step process crashes, renewals stop
+    with it and the lock expires within one TTL.
+
+    This class is backend-agnostic: the actual renewal is performed by the `renew` callable
+    (for example, a Kubernetes annotation patch for KubeRay).
+    """
+
+    def __init__(
+        self,
+        *,
+        renew: Callable[[], None],
+        interval_seconds: float,
+        logger: logging.Logger = logger,
+    ):
+        self.renew = renew
+        self.interval_seconds = interval_seconds
+        self.logger = logger
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run,
+            name="dagster-ray-lock-heartbeat",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, join_timeout: float = 10.0) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=join_timeout)
+
+    def _run(self) -> None:
+        while True:
+            try:
+                self.renew()
+            except Exception as e:
+                self.logger.warning(f"Failed to renew the cluster sharing lock: {e}")
+            if self._stop.wait(self.interval_seconds):
+                return

--- a/src/dagster_ray/kuberay/__init__.py
+++ b/src/dagster_ray/kuberay/__init__.py
@@ -1,4 +1,11 @@
-from dagster_ray.kuberay.configs import ClusterSharing, RayClusterConfig, RayClusterSpec, RayJobConfig, RayJobSpec
+from dagster_ray.kuberay.configs import (
+    ClusterSharing,
+    ClusterSharingHeartbeat,
+    RayClusterConfig,
+    RayClusterSpec,
+    RayJobConfig,
+    RayJobSpec,
+)
 from dagster_ray.kuberay.jobs import delete_kuberay_clusters
 from dagster_ray.kuberay.ops import delete_kuberay_clusters_op
 from dagster_ray.kuberay.pipes import PipesKubeRayJobClient
@@ -24,4 +31,5 @@ __all__ = [
     "KubeRayInteractiveJob",
     "KubeRayJobClientResource",
     "ClusterSharing",
+    "ClusterSharingHeartbeat",
 ]

--- a/src/dagster_ray/kuberay/configs.py
+++ b/src/dagster_ray/kuberay/configs.py
@@ -1,9 +1,11 @@
 import os
+import warnings
 from collections.abc import Mapping
 from typing import Any, Literal
 
 import dagster as dg
-from pydantic import Field
+from pydantic import Field, model_validator
+from typing_extensions import Self
 
 from dagster_ray.kuberay.utils import remove_none_from_dict
 from dagster_ray.types import AnyDagsterContext
@@ -322,6 +324,28 @@ class MatchDagsterLabels(dg.Config):
 DEFAULT_CLUSTER_SHARING_TTL_SECONDS = 30 * 60.0
 
 
+class ClusterSharingHeartbeat(dg.Config):
+    """Controls background renewal of the cluster sharing lock while the Dagster step is running.
+
+    Without renewal, the lock expires `ttl_seconds` after step start and the garbage collection
+    sensor may delete the cluster while the step is still using it. With renewal, `ttl_seconds`
+    can stay short: idle clusters are reaped promptly, active steps survive.
+
+    Each renewal updates the lock's `heartbeat_at` timestamp; `created_at` always points at the
+    initial lock placement. A hanging step renews its lock indefinitely — set the
+    `dagster/max_runtime` tag on runs to bound step runtime.
+    """
+
+    enabled: bool = Field(
+        default=True,
+        description="Whether to renew the cluster sharing lock in the background while the Dagster step is running.",
+    )
+    refresh_seconds: float = Field(
+        default=10.0,
+        description="How often to renew the lock. Must be well below `ClusterSharing.ttl_seconds` — if a renewal is missed, the lock must not have expired yet, or the cluster can be deleted mid-step.",
+    )
+
+
 class ClusterSharing(dg.Config):
     """Defines the strategy for sharing `RayCluster` resources with other Dagster steps.
 
@@ -343,5 +367,29 @@ class ClusterSharing(dg.Config):
     )
     ttl_seconds: float = Field(
         default=DEFAULT_CLUSTER_SHARING_TTL_SECONDS,
-        description="Time to live for the lock placed on the `RayCluster` resource, marking it as in use by the current Dagster step.",
+        description="Time to live for the lock placed on the `RayCluster` resource, marking it as in use by the current Dagster step. The lock is renewed periodically while the step is running (see `heartbeat`), so this only needs to cover the gap between renewals.",
     )
+    heartbeat: ClusterSharingHeartbeat = Field(
+        default_factory=ClusterSharingHeartbeat,
+        description="Configuration for background renewal of the cluster sharing lock while the Dagster step is running.",
+    )
+
+    @model_validator(mode="after")
+    def _warn_on_low_heartbeat_headroom(self) -> Self:
+        """Warn on a misconfiguration that would silently reintroduce mid-step deletion.
+
+        The heartbeat renews the lock every `refresh_seconds`; the lock expires `ttl_seconds`
+        after the last renewal. If `refresh_seconds` isn't comfortably below `ttl_seconds`, a
+        single missed renewal (a slow API call, a paused thread) lets the lock expire while the
+        step is still running, and the garbage collection sensor may delete the cluster mid-step.
+        We recommend at least 2x headroom.
+        """
+        if self.enabled and self.heartbeat.enabled and self.heartbeat.refresh_seconds * 2 > self.ttl_seconds:
+            warnings.warn(
+                f"cluster_sharing.heartbeat.refresh_seconds ({self.heartbeat.refresh_seconds}) should be at most "
+                f"half of cluster_sharing.ttl_seconds ({self.ttl_seconds}) so a missed heartbeat can't let the "
+                f"lock expire while the step is still running, which would let the garbage collection sensor "
+                f"delete the cluster mid-step. Lower refresh_seconds or raise ttl_seconds.",
+                stacklevel=2,
+            )
+        return self

--- a/src/dagster_ray/kuberay/resources/raycluster.py
+++ b/src/dagster_ray/kuberay/resources/raycluster.py
@@ -3,10 +3,10 @@ from datetime import datetime
 from typing import cast
 
 import dagster as dg
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 from typing_extensions import override
 
-from dagster_ray._base.cluster_sharing_lock import ClusterSharingLock
+from dagster_ray._base.cluster_sharing_lock import ClusterSharingLock, ClusterSharingLockHeartbeat
 from dagster_ray.configs import Lifecycle
 from dagster_ray.kuberay.client import RayClusterClient
 from dagster_ray.kuberay.configs import ClusterSharing, RayClusterConfig
@@ -64,6 +64,9 @@ class KubeRayCluster(BaseKubeRayResource):
         description="Whether to log RayCluster conditions while waiting for the RayCluster to become ready. Learn more: [KubeRay docs](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/observability.html#raycluster-status-conditions).",
     )
 
+    _sharing_lock: ClusterSharingLock | None = PrivateAttr(default=None)
+    _sharing_lock_heartbeat: ClusterSharingLockHeartbeat | None = PrivateAttr(default=None)
+
     @property
     def host(self) -> str:
         if self._host is None:
@@ -114,8 +117,14 @@ class KubeRayCluster(BaseKubeRayResource):
         """Mark an existing cluster as being used by this step."""
         self._name = cluster_name
         self._creation_verb = "Using"
+        self._place_sharing_lock(context)
 
-        # Place a lock on the cluster using JSON patch to avoid overwriting existing annotations
+    def _place_sharing_lock(self, context: AnyDagsterContext) -> None:
+        """Stamp this step's sharing lock annotation on the cluster.
+
+        Uses a JSON patch so other annotations (including other steps' locks) are preserved,
+        while repeated calls overwrite this step's own lock in place.
+        """
         lock_annotations = self.get_sharing_lock_annotations(context)
         patch_operations = [
             {
@@ -127,7 +136,7 @@ class KubeRayCluster(BaseKubeRayResource):
         ]
 
         self.client.update_json_patch(
-            name=cluster_name,
+            name=self.name,
             namespace=self.namespace,
             body=patch_operations,
         )
@@ -254,6 +263,31 @@ class KubeRayCluster(BaseKubeRayResource):
                     context.log.debug(f"Failed to release leader election lease: {e}")
 
     @override
+    def on_create(self, context: AnyDagsterContext):
+        super().on_create(context)
+        if self.cluster_sharing.enabled and self.cluster_sharing.heartbeat.enabled:
+            self._start_sharing_lock_heartbeat(context)
+
+    def _start_sharing_lock_heartbeat(self, context: AnyDagsterContext) -> None:
+        assert context.log is not None
+        self._sharing_lock_heartbeat = ClusterSharingLockHeartbeat(
+            renew=lambda: self._renew_sharing_lock(context),
+            interval_seconds=self.cluster_sharing.heartbeat.refresh_seconds,
+            logger=context.log,
+        )
+        self._sharing_lock_heartbeat.start()
+
+    def _renew_sharing_lock(self, context: AnyDagsterContext) -> None:
+        """Re-stamp this step's lock annotation with a fresh `heartbeat_at`, preserving `created_at`."""
+        self._sharing_lock = self.get_sharing_lock(context).renewed()
+        self._place_sharing_lock(context)
+
+    def _stop_sharing_lock_heartbeat(self) -> None:
+        if self._sharing_lock_heartbeat is not None:
+            self._sharing_lock_heartbeat.stop()
+            self._sharing_lock_heartbeat = None
+
+    @override
     def wait(self, context: AnyDagsterContext):
         assert context.log is not None
         assert context.dagster_run is not None
@@ -289,6 +323,8 @@ class KubeRayCluster(BaseKubeRayResource):
     def cleanup(self, context: AnyDagsterContext, exception: BaseException | None):
         assert context.log is not None
         assert context.run_id is not None
+        # stop renewing the sharing lock so it can expire once this step is done
+        self._stop_sharing_lock_heartbeat()
         # we don't want to perform cleanup if:
         # - cluster sharing is enabled
         # - cluster has at least one lock that hasn't expired yet
@@ -336,14 +372,22 @@ class KubeRayCluster(BaseKubeRayResource):
 
         return ",".join([f"{key}={value}" for key, value in combined_match_labels.items()])
 
+    def get_sharing_lock(self, context: AnyDagsterContext) -> ClusterSharingLock:
+        """This step's sharing lock. Created once: `created_at` always points at the initial lock placement."""
+        lock = self._sharing_lock
+        if lock is None:
+            run = get_dagster_run(context)
+            lock = ClusterSharingLock(
+                run_id=run.run_id,
+                key=self.resource_uid,
+                ttl_seconds=self.cluster_sharing.ttl_seconds,
+                created_at=datetime.now(),
+            )
+            self._sharing_lock = lock
+        return lock
+
     def get_sharing_lock_annotations(self, context: AnyDagsterContext) -> dict[str, str]:
-        run = get_dagster_run(context)
-        lock = ClusterSharingLock(
-            run_id=run.run_id,
-            key=self.resource_uid,
-            ttl_seconds=self.cluster_sharing.ttl_seconds,
-            created_at=datetime.now(),
-        )
+        lock = self.get_sharing_lock(context)
         return {lock.tag: lock.model_dump_json()}
 
     def get_cluster_sharing_alive_locks(self, context: AnyDagsterContext) -> Sequence[ClusterSharingLock]:

--- a/src/dagster_ray/kuberay/sensors.py
+++ b/src/dagster_ray/kuberay/sensors.py
@@ -21,11 +21,16 @@ def cleanup_expired_kuberay_clusters(
     context: dg.SensorEvaluationContext,
     raycluster_client: dg.ResourceParam[RayClusterClient],
 ) -> Generator[dg.RunRequest | dg.SkipReason, None, None]:
-    f"""A Dagster sensor that monitors shared `RayCluster` resources created by the current code location and submits jobs to delete clusters that either:
-        - use [Cluster Sharing](../tutorial/#cluster-sharing) (`dagster/cluster-sharing=true`) and have expired
-        - are older than `DAGSTER_RAY_CLUSTER_EXPIRATION_SECONDS` (defaults to 4 hours)
+    """A Dagster sensor that monitors shared `RayCluster` resources created by the current code location and submits jobs to delete clusters that either:
 
-    By default it monitors the `ray` namespace. This can be configured by setting `{DAGSTER_RAY_NAMESPACES_ENV_VAR}` (accepts a comma-separated list of namespaces)."""
+    - use [Cluster Sharing](../tutorial/kuberay.md#cluster-sharing) (`dagster/cluster-sharing=true`) and have expired
+    - are older than `DAGSTER_RAY_CLUSTER_EXPIRATION_SECONDS` (defaults to 4 hours)
+
+    A sharing lock expires `ttl_seconds` after its last heartbeat, so clusters with actively heartbeating locks are never deleted.
+    Set the `dagster/max_runtime` tag on runs to prevent hanging steps from renewing their lock forever.
+
+    By default it monitors the `ray` namespace. This can be configured by setting `DAGSTER_RAY_NAMESPACES` (accepts a comma-separated list of namespaces).
+    """
     assert context.code_location_origin is not None
 
     found_any = False

--- a/tests/kuberay/test_raycluster.py
+++ b/tests/kuberay/test_raycluster.py
@@ -1,5 +1,7 @@
 import socket
+import threading
 import time
+import warnings
 from datetime import datetime, timedelta
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -20,7 +22,7 @@ from dagster_ray.kuberay import (
     cleanup_expired_kuberay_clusters,
 )
 from dagster_ray.kuberay.client import RayClusterClient
-from dagster_ray.kuberay.configs import ClusterSharing, RayClusterSpec
+from dagster_ray.kuberay.configs import ClusterSharing, ClusterSharingHeartbeat, RayClusterSpec
 from dagster_ray.kuberay.jobs import delete_kuberay_clusters
 from dagster_ray.kuberay.ops import DeleteKubeRayClustersConfig, RayClusterRef
 from dagster_ray.kuberay.utils import k8s_service_fqdn
@@ -667,3 +669,119 @@ def test_job_submission_client_uses_fqdn():
         cookies=None,
         metadata=None,
     )
+
+
+def test_place_sharing_lock_patches_annotation_in_place():
+    """Lock renewal re-stamps this step's own annotation via a JSON patch on the same key,
+    so it overwrites the lock in place (fresh `created_at`) without touching other steps' locks."""
+    resource = MagicMock()
+    resource.name = "dg-test-cluster"
+    resource.namespace = "ray"
+    lock_key = "dagster/lock-run123-abcd1234"
+    lock_value = '{"run_id": "run123"}'
+    resource.get_sharing_lock_annotations.return_value = {lock_key: lock_value}
+
+    KubeRayCluster._place_sharing_lock(resource, MagicMock())
+
+    resource.client.update_json_patch.assert_called_once_with(
+        name="dg-test-cluster",
+        namespace="ray",
+        body=[
+            {
+                "op": "add",
+                # '/' in the annotation key is escaped as '~1' per JSON Pointer
+                "path": "/metadata/annotations/dagster~1lock-run123-abcd1234",
+                "value": lock_value,
+            }
+        ],
+    )
+
+
+def test_renew_sharing_lock_preserves_created_at():
+    """Renewals update `heartbeat_at` only: `created_at` always points at the initial lock
+    placement, and the annotation key stays the same, so the lock is overwritten in place."""
+    resource = KubeRayCluster(cluster_sharing=ClusterSharing(enabled=True))
+    context = MagicMock()
+    context.run.run_id = "run123"
+
+    with patch.object(KubeRayCluster, "_place_sharing_lock"):
+        original = resource.get_sharing_lock(context)
+        assert original.heartbeat_at is None
+
+        resource._renew_sharing_lock(context)
+
+        renewed = resource.get_sharing_lock(context)
+        assert renewed.heartbeat_at is not None
+        assert renewed.created_at == original.created_at
+        assert renewed.tag == original.tag
+
+
+def test_sharing_lock_heartbeat_lifecycle():
+    """`on_create` starts the heartbeat (with an immediate renewal) when cluster sharing is
+    enabled; `cleanup` stops it."""
+    resource = KubeRayCluster(cluster_sharing=ClusterSharing(enabled=True))
+    context = MagicMock()
+
+    renewed = threading.Event()
+    with (
+        patch.object(KubeRayCluster, "_renew_sharing_lock", side_effect=lambda _ctx: renewed.set()),
+        patch.object(KubeRayCluster, "get_cluster_sharing_alive_locks", return_value=[]),
+    ):
+        resource.on_create(context)
+
+        heartbeat = resource._sharing_lock_heartbeat
+        assert heartbeat is not None
+        assert heartbeat.is_running
+        assert renewed.wait(timeout=2), "expected an immediate lock renewal on heartbeat start"
+
+        resource.cleanup(context, None)
+
+        assert resource._sharing_lock_heartbeat is None
+        assert not heartbeat.is_running
+
+
+def test_sharing_lock_heartbeat_can_be_disabled():
+    resource = KubeRayCluster(
+        cluster_sharing=ClusterSharing(enabled=True, heartbeat=ClusterSharingHeartbeat(enabled=False))
+    )
+    resource.on_create(MagicMock())
+    assert resource._sharing_lock_heartbeat is None
+
+
+def test_no_sharing_lock_heartbeat_without_cluster_sharing():
+    resource = KubeRayCluster()
+    resource.on_create(MagicMock())
+    assert resource._sharing_lock_heartbeat is None
+
+
+def _refresh_warnings(**kwargs) -> list[str]:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        ClusterSharing(**kwargs)
+    return [str(w.message) for w in caught if "refresh_seconds" in str(w.message)]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # default refresh (10) is well below the default ttl (1800)
+        dict(enabled=True),
+        # exactly 2x headroom is allowed
+        dict(enabled=True, ttl_seconds=20, heartbeat=ClusterSharingHeartbeat(refresh_seconds=10)),
+        # cluster sharing disabled: the heartbeat never runs, so the ratio is irrelevant
+        dict(enabled=False, ttl_seconds=5, heartbeat=ClusterSharingHeartbeat(refresh_seconds=10)),
+        # heartbeat disabled: the lock is never renewed, so the ratio is irrelevant
+        dict(enabled=True, ttl_seconds=5, heartbeat=ClusterSharingHeartbeat(enabled=False, refresh_seconds=10)),
+    ],
+)
+def test_cluster_sharing_no_warning_with_enough_heartbeat_headroom(kwargs):
+    assert _refresh_warnings(**kwargs) == []
+
+
+def test_cluster_sharing_warns_on_low_heartbeat_headroom():
+    """Less than 2x headroom means a single missed renewal can let the lock expire mid-step."""
+    warnings_raised = _refresh_warnings(
+        enabled=True, ttl_seconds=15, heartbeat=ClusterSharingHeartbeat(refresh_seconds=10)
+    )
+    assert len(warnings_raised) == 1
+    assert "ttl_seconds" in warnings_raised[0]

--- a/tests/test_cluster_sharing_lock.py
+++ b/tests/test_cluster_sharing_lock.py
@@ -1,0 +1,96 @@
+import threading
+import time
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+from dagster_ray._base.cluster_sharing_lock import ClusterSharingLock, ClusterSharingLockHeartbeat
+
+
+def make_lock(**kwargs) -> ClusterSharingLock:
+    defaults = {
+        "run_id": "run123",
+        "key": "stepA",
+        "created_at": datetime.now(),
+        "ttl_seconds": 60.0,
+    }
+    defaults.update(kwargs)
+    return ClusterSharingLock(**defaults)
+
+
+def test_lock_expiry_counts_from_last_heartbeat():
+    lock = make_lock(created_at=datetime.now() - timedelta(seconds=100), ttl_seconds=10.0)
+    assert lock.is_expired
+
+    renewed = lock.renewed()
+    assert not renewed.is_expired
+    assert renewed.heartbeat_at is not None
+    # created_at is static: renewals never change it
+    assert renewed.created_at == lock.created_at
+
+
+def test_lock_without_heartbeat_behaves_as_before():
+    """Locks placed by older dagster-ray versions have no `heartbeat_at` and must keep the
+    original expiry semantics: `created_at + ttl_seconds`."""
+    old_json = '{"run_id": "run123", "key": "stepA", "created_at": "2020-01-01T10:00:00", "ttl_seconds": 60.0}'
+    lock = ClusterSharingLock.model_validate_json(old_json)
+    assert lock.heartbeat_at is None
+    assert lock.alive_at == lock.created_at
+    assert lock.is_expired
+
+
+def test_get_alive_locks_respects_heartbeats():
+    """An old but actively heartbeating lock is alive; the same lock without a heartbeat is not."""
+    stale = make_lock(created_at=datetime.now() - timedelta(seconds=1000), ttl_seconds=10.0)
+    fresh = stale.renewed()
+
+    assert list(ClusterSharingLock.get_alive_locks([stale])) == []
+    assert list(ClusterSharingLock.get_alive_locks([fresh])) == [fresh]
+
+
+def test_heartbeat_renews_immediately():
+    """The first renewal must happen at startup, not after the first interval: by the time the
+    heartbeat starts, the lock may already be almost as old as the cluster provisioning wait."""
+    renewed = threading.Event()
+    heartbeat = ClusterSharingLockHeartbeat(renew=renewed.set, interval_seconds=100.0)
+    heartbeat.start()
+    try:
+        assert renewed.wait(timeout=2), "expected an immediate renewal, not one delayed by the interval"
+    finally:
+        heartbeat.stop()
+    assert not heartbeat.is_running
+
+
+def test_heartbeat_renews_until_stopped():
+    renewals: list[int] = []
+    heartbeat = ClusterSharingLockHeartbeat(renew=lambda: renewals.append(1), interval_seconds=0.02)
+    heartbeat.start()
+    time.sleep(0.15)
+    heartbeat.stop()
+
+    assert not heartbeat.is_running
+    assert len(renewals) >= 2
+
+
+def test_heartbeat_survives_renewal_errors():
+    """A failing renewal (e.g. the cluster was already deleted, or a transient API error) is
+    logged, not raised, and the loop keeps going until stopped."""
+    renew = MagicMock(side_effect=RuntimeError("boom"))
+    logger = MagicMock()
+    heartbeat = ClusterSharingLockHeartbeat(renew=renew, interval_seconds=0.02, logger=logger)
+    heartbeat.start()
+    time.sleep(0.1)
+    heartbeat.stop()
+
+    assert not heartbeat.is_running
+    assert renew.call_count >= 2
+    assert logger.warning.called
+
+
+def test_heartbeat_start_is_idempotent():
+    heartbeat = ClusterSharingLockHeartbeat(renew=MagicMock(), interval_seconds=100.0)
+    heartbeat.start()
+    thread = heartbeat._thread
+    heartbeat.start()
+    assert heartbeat._thread is thread
+    heartbeat.stop()
+    assert not heartbeat.is_running


### PR DESCRIPTION
The Dagster `KubeRayCluster` resource now (by default) spawns a background thread that publishes heartbeats (as Kubernetes annotations) to the `RayCluster` currently in use. 

The garbage collection sensors respects these heartbeats and does not delete clusters that are currently in use. 